### PR TITLE
rtx: presumably fix gray textures

### DIFF
--- a/ref_vk/shaders/rtx.comp
+++ b/ref_vk/shaders/rtx.comp
@@ -491,7 +491,7 @@ void main() {
 		// 		C += kc * vec3(hash(float(kusok_index)-102.3), hash(float(kusok_index)+15.43), hash(float(kusok_index)+34.));//kusok.emissive.rgb;
 		//}
 
-		kc *= .9;
+		kc *= .9 * baseColor;
 		//const float rough = .4;
 		const float rough = .3;// * hash(.01 * dot(floor((inverse(mat4(transform)) * vec4(pos, 1.))/10.).xyz, vec3(1.)));
 		O = pos;


### PR DESCRIPTION
Modulate the subsequent bounces with texture color. This makes it
consistent with the way surface lights and dlights work.