### PR TITLE
concat brush drawcalls

### DIFF
--- a/ref_vk/TODO.md
+++ b/ref_vk/TODO.md
@@ -1,5 +1,6 @@
 ## 2021-08-15, E126
 - [x] restore render debug labels
+- [x] restore draw call concatenation; brush geoms are generated in a way that makes concatenating them impossible
 
 # Next
 - [ ] rtx: split ray tracing into modules: pipeline mgmt, buffer mgmt
@@ -12,9 +13,9 @@
 		uint8_t data[];
 
 # Planned
+- [ ] filter things to render, e.g.: some sprites are there to fake bloom, we don't need to draw them in rtx mode
 - [ ] make a list of all possible materials, categorize them and figure out what to do
 - [ ] possibly split vk_render into (a) rendering/pipeline, (b) buffer management/allocation, (c) render state
-- [ ] restore draw call concatenation; brush geoms are generated in a way that makes concatenating them impossible
 - [ ] rtx: light styles: need static lights data, not clear how and what to do
 - [ ] studio models: fix lighting: should have white texture instead of lightmap OR we could write nearest surface lightmap coords to fake light
 	- [ ] make it look correct lol

--- a/ref_vk/vk_brush.c
+++ b/ref_vk/vk_brush.c
@@ -474,9 +474,9 @@ static qboolean loadBrushSurfaces( model_sizes_t sizes, const model_t *mod ) {
 			}
 
 			model_geometry->surf = surf;
-			model_geometry->texture = t;
+			model_geometry->texture = surf->texinfo->texture->gl_texturenum;
 
-			model_geometry->vertex_offset = vertex_buffer.buffer.unit.offset + vertex_offset;
+			model_geometry->vertex_offset = vertex_buffer.buffer.unit.offset;
 			model_geometry->vertex_count = surf->numedges;
 
 			model_geometry->index_offset = index_offset;
@@ -530,9 +530,9 @@ static qboolean loadBrushSurfaces( model_sizes_t sizes, const model_t *mod ) {
 
 				// Ray tracing apparently expects triangle list only (although spec is not very clear about this kekw)
 				if (k > 1) {
-					*(bind++) = (uint16_t)(0);
-					*(bind++) = (uint16_t)(k - 1);
-					*(bind++) = (uint16_t)(k);
+					*(bind++) = (uint16_t)(vertex_offset + 0);
+					*(bind++) = (uint16_t)(vertex_offset + k - 1);
+					*(bind++) = (uint16_t)(vertex_offset + k);
 					index_count += 3;
 					index_offset += 3;
 				}


### PR DESCRIPTION
make all geoms share the same constant vertex offset so that continuous indices can be exploited to generate only a single draw call for a group of geometries with the same texture