### PR TITLE
rtx: calculate maxVertex correctly

### DIFF
--- a/ref_vk/vk_beams.c
+++ b/ref_vk/vk_beams.c
@@ -385,7 +385,7 @@ static void R_DrawSegs( vec3_t source, vec3_t delta, float width, float scale, f
 			.texture = texture,
 			.material = kXVkMaterialDiffuse,
 
-			.vertex_count = total_vertices,
+			.max_vertex = total_vertices,
 			.vertex_offset = vertex_buffer.buffer.unit.offset,
 
 			.element_count = total_indices,

--- a/ref_vk/vk_brush.c
+++ b/ref_vk/vk_brush.c
@@ -208,7 +208,7 @@ static void EmitWaterPolys( const cl_entity_t *ent, const msurface_t *warp, qboo
 			.texture = warp->texinfo->texture->gl_texturenum, // FIXME assert >= 0
 			.material = kXVkMaterialWater,
 
-			.vertex_count = num_vertices,
+			.max_vertex = num_vertices,
 			.vertex_offset = vertex_buffer.buffer.unit.offset,
 
 			.element_count = num_indices,
@@ -477,7 +477,7 @@ static qboolean loadBrushSurfaces( model_sizes_t sizes, const model_t *mod ) {
 			model_geometry->texture = surf->texinfo->texture->gl_texturenum;
 
 			model_geometry->vertex_offset = vertex_buffer.buffer.unit.offset;
-			model_geometry->vertex_count = surf->numedges;
+			model_geometry->max_vertex = vertex_offset + surf->numedges;
 
 			model_geometry->index_offset = index_offset;
 

--- a/ref_vk/vk_ray_model.c
+++ b/ref_vk/vk_ray_model.c
@@ -191,7 +191,7 @@ vk_ray_model_t* VK_RayModelCreate( vk_ray_model_init_t args ) {
 					(VkAccelerationStructureGeometryTrianglesDataKHR){
 						.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR,
 						.indexType = VK_INDEX_TYPE_UINT16,
-						.maxVertex = mg->vertex_count,
+						.maxVertex = mg->max_vertex,
 						.vertexFormat = VK_FORMAT_R32G32B32_SFLOAT,
 						.vertexStride = sizeof(vk_vertex_t),
 						.vertexData.deviceAddress = buffer_addr,

--- a/ref_vk/vk_render.h
+++ b/ref_vk/vk_render.h
@@ -76,7 +76,9 @@ typedef struct {
 	XVkMaterialType material;
 
 	uint32_t element_count;
-	uint32_t vertex_count;
+
+	// Maximum index of vertex used for this geometry; needed for ray tracing BLAS building
+	uint32_t max_vertex;
 
 	// Non-null only for brush models
 	// Used for:

--- a/ref_vk/vk_sprite.c
+++ b/ref_vk/vk_sprite.c
@@ -707,7 +707,7 @@ static void R_DrawSpriteQuad( const char *debug_name, mspriteframe_t *frame, vec
 			.texture = texture,
 			.material = kXVkMaterialDiffuse,
 
-			.vertex_count = 4,
+			.max_vertex = 4,
 			.vertex_offset = vertex_buffer.buffer.unit.offset,
 
 			.element_count = 6,

--- a/ref_vk/vk_studio.c
+++ b/ref_vk/vk_studio.c
@@ -2005,7 +2005,7 @@ static void R_StudioDrawNormalMesh( short *ptricmds, vec3_t *pstudionorms, float
 			.material = kXVkMaterialDiffuse,
 
 			.vertex_offset = vertex_buffer.buffer.unit.offset,
-			.vertex_count = num_vertices,
+			.max_vertex = num_vertices,
 
 			.index_offset = index_buffer.buffer.unit.offset,
 			.element_count = num_indices,


### PR DESCRIPTION
after we've updated how brush index buffer references vertices to allow
for draw call coalescing ray tracing broke on amd.
this is because amd cards expect a correct value in
VkAccelerationStructureGeometryTrianglesDataKHR::maxVertex. make sure we
fill a correct value there.