### PR TITLE
patch: enable live reloading, fix #281

### DIFF
--- a/ref_vk/vk_brush.c
+++ b/ref_vk/vk_brush.c
@@ -509,12 +509,6 @@ static qboolean loadBrushSurfaces( model_sizes_t sizes, const model_t *mod ) {
 				model_geometry->material = kXVkMaterialConveyor;
 			}
 
-			// FIXME material should be flags
-			if (psurf && psurf->flags & Patch_Surface_Emissive) {
-				model_geometry->material = kXVkMaterialEmissive;
-				VectorCopy(psurf->emissive, model_geometry->emissive);
-			}
-
 			VectorCopy(surf->texinfo->vecs[0], tangent);
 			VectorNormalize(tangent);
 

--- a/ref_vk/vk_scene.c
+++ b/ref_vk/vk_scene.c
@@ -45,12 +45,20 @@ static struct {
 	draw_list_t	*draw_list;
 } g_lists;
 
+static void reloadPatches( void ) {
+	XVK_ParseMapEntities();
+
+	// Assumes that the map has been loaded
+	VK_LightsLoadMapStaticLights();
+}
+
 void VK_SceneInit( void )
 {
 	g_lists.draw_list = g_lists.draw_stack;
 	g_lists.draw_stack_pos = 0;
 	if (vk_core.rtx) {
 		gEngine.Cmd_AddCommand("vk_rtx_reload_materials", XVK_ReloadMaterials, "Reload PBR materials");
+		gEngine.Cmd_AddCommand("vk_rtx_reload_patches", reloadPatches, "Reload patches (does not update surface deletion)");
 	}
 }
 


### PR DESCRIPTION
Does not yet reload emissive patches ("_light" argument for surfaces).
Does not reload deleted surfaces.