### PR TITLE
rtx: denoiser for global illumitation with spherical harmonics

### DIFF
--- a/ref_vk/shaders/denoiser.comp
+++ b/ref_vk/shaders/denoiser.comp
@@ -16,10 +16,10 @@ layout(set = 0, binding = 6, rgba16f) uniform readonly image2D src_sh1_blured;
 layout(set = 0, binding = 7, rgba16f) uniform readonly image2D src_sh2_blured;
 
 // depth fading of blur
-const float gi_depth_fade_distance = 2.;
+const float gi_depth_fade_distance = 3.;
 
 // global illunitation exposition
-const float gi_multiplier = 0.3;
+const float gi_multiplier = 4.0;
 
 
 // Blatantly copypasted from https://www.shadertoy.com/view/XsGfWV
@@ -127,8 +127,8 @@ void main() {
 
 			// TODO bilaterally filter shading normals
 
-			//colour += scale * imageLoad(src_diffuse_gi, p).rgb;
-			//total_scale += scale;
+			colour += scale * imageLoad(src_diffuse_gi, p).rgb;
+			total_scale += scale;
 
 			const int SPECULAR_KERNEL_SIZE = 2;
 			if (all(lessThan(abs(ivec2(x, y)), ivec2(SPECULAR_KERNEL_SIZE)))) {
@@ -139,16 +139,16 @@ void main() {
 			}
 		}
 
-//	if (total_scale > 0.) {
-//		colour /= total_scale;
-//		colour *= base_color.rgb;
-//	}
-//
-//	if (specular_total_scale > 0.) {
-//		speculour /= specular_total_scale;
-//		//speculour *= base_color.rgb;
-//		colour += speculour;
-//	}
+	if (total_scale > 0.) {
+		colour /= total_scale;
+		colour *= base_color.rgb;
+	}
+
+	if (specular_total_scale > 0.) {
+		speculour /= specular_total_scale;
+		//speculour *= base_color.rgb;
+		colour += speculour;
+	}
 
 	if (gi_total_scale > 0.) {
 		colour_gi /= gi_total_scale ;

--- a/ref_vk/shaders/denoiser.comp
+++ b/ref_vk/shaders/denoiser.comp
@@ -87,6 +87,9 @@ void main() {
 	/* return; */
 
 	SH low_freq;
+	low_freq.shY = vec4(0.);
+	low_freq.CoCg = vec2(0.);
+
 	const int KERNEL_SIZE = 8;
 	float total_scale = 0.;
 	float specular_total_scale = 0.;
@@ -111,10 +114,9 @@ void main() {
 			const float depth_gradient = fade_by_depth(current_depth, depth, gi_depth_fade_distance);
 			const float scale = normpdf(x, sigma) * normpdf(y, sigma) * depth_gradient;
 
-			low_freq.shY = sh1;
-			low_freq.CoCg = sh2_and_depth.xy;
+			low_freq.shY += sh1 * scale;
+			low_freq.CoCg += sh2_and_depth.xy * scale;
 
-			colour_gi += project_SH_irradiance(low_freq, worldspace_normal) * scale / STORAGE_SCALE_LF;
 			gi_total_scale += scale;
 
 			const vec4 c = imageLoad(src_diffuse_gi, p);
@@ -130,7 +132,7 @@ void main() {
 			colour += scale * imageLoad(src_diffuse_gi, p).rgb;
 			total_scale += scale;
 
-			const int SPECULAR_KERNEL_SIZE = 2;
+			const int SPECULAR_KERNEL_SIZE = 4;
 			if (all(lessThan(abs(ivec2(x, y)), ivec2(SPECULAR_KERNEL_SIZE)))) {
 				const float spigma = SPECULAR_KERNEL_SIZE / 2.;
 				const float specuale = normpdf(x, spigma) * normpdf(y, spigma);
@@ -151,7 +153,7 @@ void main() {
 	}
 
 	if (gi_total_scale > 0.) {
-		colour_gi /= gi_total_scale ;
+		colour_gi = project_SH_irradiance(low_freq, worldspace_normal) / (gi_total_scale * STORAGE_SCALE_LF);
 		colour += colour_gi * base_color.rgb * gi_multiplier;
 	}
 

--- a/ref_vk/shaders/denoiser.comp
+++ b/ref_vk/shaders/denoiser.comp
@@ -1,6 +1,7 @@
 #version 460
 
 #include "noise.glsl"
+#include "spherical_harmonics.glsl"
 
 layout(local_size_x = 16, local_size_y = 8, local_size_z = 1) in;
 
@@ -11,6 +12,15 @@ layout(set = 0, binding = 2, rgba16f) uniform readonly image2D src_diffuse_gi;
 layout(set = 0, binding = 3, rgba16f) uniform readonly image2D src_specular;
 layout(set = 0, binding = 4, rgba16f) uniform readonly image2D src_additive;
 layout(set = 0, binding = 5, rgba16f) uniform readonly image2D src_normals;
+layout(set = 0, binding = 6, rgba16f) uniform readonly image2D src_sh1_blured;
+layout(set = 0, binding = 7, rgba16f) uniform readonly image2D src_sh2_blured;
+
+// depth fading of blur
+const float gi_depth_fade_distance = 2.;
+
+// global illunitation exposition
+const float gi_multiplier = 0.3;
+
 
 // Blatantly copypasted from https://www.shadertoy.com/view/XsGfWV
 vec3 aces_tonemap(vec3 color){
@@ -64,8 +74,11 @@ void main() {
 	//imageStore(dest, pix, vec4(aces_tonemap(imageLoad(src_diffuse_gi, pix).rgb), 0.)); return;
 	//imageStore(dest, pix, vec4(aces_tonemap(imageLoad(src_specular, pix).rgb), 0.)); return;
 
-	vec3 geometry_normal, shading_normal;
-	readNormals(pix, geometry_normal, shading_normal);
+	//vec3 geometry_normal, shading_normal;
+	//readNormals(pix, geometry_normal, shading_normal);
+
+	vec3 worldspace_normal = imageLoad(src_normals, pix).xyz;
+	float depth = imageLoad(src_sh2_blured, pix).z;
 
 	//imageStore(dest, pix, vec4(.5 + geometry_normal * .5, 0.)); return;
 
@@ -73,11 +86,14 @@ void main() {
 	/* imageStore(dest, pix, vec4(rand3_f01(uvec3(mi,mi+1,mi+2)), 0.)); */
 	/* return; */
 
+	SH low_freq;
 	const int KERNEL_SIZE = 8;
 	float total_scale = 0.;
 	float specular_total_scale = 0.;
+	float gi_total_scale = 0.;
 	vec3 colour = vec3(0.);
 	vec3 speculour = vec3(0.);
+	vec3 colour_gi = vec3(0.);
 	for (int x = -KERNEL_SIZE; x <= KERNEL_SIZE; ++x)
 		for (int y = -KERNEL_SIZE; y <= KERNEL_SIZE; ++y) {
 			const ivec2 p = pix + ivec2(x, y);
@@ -85,23 +101,34 @@ void main() {
 				continue;
 			}
 
+			const vec3 current_normal = imageLoad(src_normals, p).xyz;
+
+			const vec4 sh1 = imageLoad(src_sh1_blured, p);
+			const vec4 sh2_and_depth = imageLoad(src_sh2_blured, p);
+			const float current_depth = sh2_and_depth.z;
+
+			const float sigma = KERNEL_SIZE / 2.;
+			const float depth_gradient = fade_by_depth(current_depth, depth, gi_depth_fade_distance);
+			const float scale = normpdf(x, sigma) * normpdf(y, sigma) * depth_gradient;
+
+			low_freq.shY = sh1;
+			low_freq.CoCg = sh2_and_depth.xy;
+
+			colour_gi += project_SH_irradiance(low_freq, worldspace_normal) * scale / STORAGE_SCALE_LF;
+			gi_total_scale += scale;
+
 			const vec4 c = imageLoad(src_diffuse_gi, p);
 			if (c.a != material_index)
 				continue;
 
-			vec3 sample_geometry_normal, sample_shading_normal;
-			readNormals(p, sample_geometry_normal, sample_shading_normal);
-
-			// FIXME also filter by depth, (kusok index?), etc
-			if ( dot(sample_geometry_normal, geometry_normal) < .99 )
+			// FIXME also filter by depth
+			if ( dot(worldspace_normal, current_normal) < .99 )
 				continue;
 
 			// TODO bilaterally filter shading normals
 
-			const float sigma = KERNEL_SIZE / 2.;
-			const float scale = normpdf(x, sigma) * normpdf(y, sigma);
-			colour += scale * imageLoad(src_diffuse_gi, p).rgb;
-			total_scale += scale;
+			//colour += scale * imageLoad(src_diffuse_gi, p).rgb;
+			//total_scale += scale;
 
 			const int SPECULAR_KERNEL_SIZE = 2;
 			if (all(lessThan(abs(ivec2(x, y)), ivec2(SPECULAR_KERNEL_SIZE)))) {
@@ -112,15 +139,20 @@ void main() {
 			}
 		}
 
-	if (total_scale > 0.) {
-		colour /= total_scale;
-		colour *= base_color.rgb;
-	}
+//	if (total_scale > 0.) {
+//		colour /= total_scale;
+//		colour *= base_color.rgb;
+//	}
+//
+//	if (specular_total_scale > 0.) {
+//		speculour /= specular_total_scale;
+//		//speculour *= base_color.rgb;
+//		colour += speculour;
+//	}
 
-	if (specular_total_scale > 0.) {
-		speculour /= specular_total_scale;
-		//speculour *= base_color.rgb;
-		colour += speculour;
+	if (gi_total_scale > 0.) {
+		colour_gi /= gi_total_scale ;
+		colour += colour_gi * base_color.rgb * gi_multiplier;
 	}
 
 	//colour += imageLoad(src_specular, pix).rgb;

--- a/ref_vk/shaders/denoiser_sh.comp
+++ b/ref_vk/shaders/denoiser_sh.comp
@@ -17,10 +17,10 @@ layout(set = 0, binding = 3, rgba16f) uniform image2D src_indirect_sh2;
 
 // offset between samples, additional bluring on compose make this way right
 // ivec2(1,1) - it'is like no offset, but it's need for larger area of collection
-const ivec2 uv_offset = ivec2(3,3);
+const ivec2 uv_offset = ivec2(5,5);
 
 // max offset is uv_offset*blur_kernel_size, recommended ivec2(4,4) and blur_kernel_size = 8
-const int blur_kernel_size = 24;
+const int blur_kernel_size = 12;
 
 // depth edge of accumulation of one lightprobe
 const float gi_depth_fade_distance = 3.;

--- a/ref_vk/shaders/denoiser_sh.comp
+++ b/ref_vk/shaders/denoiser_sh.comp
@@ -17,7 +17,7 @@ layout(set = 0, binding = 3, rgba16f) uniform image2D src_indirect_sh2;
 
 // offset between samples, additional bluring on compose make this way right
 // ivec2(1,1) - it'is like no offset, but it's need for larger area of collection
-const ivec2 uv_offset = ivec2(2,2);
+const ivec2 uv_offset = ivec2(3,3);
 
 // max offset is uv_offset*blur_kernel_size, recommended ivec2(4,4) and blur_kernel_size = 8
 const int blur_kernel_size = 24;

--- a/ref_vk/shaders/denoiser_sh.comp
+++ b/ref_vk/shaders/denoiser_sh.comp
@@ -23,7 +23,7 @@ const ivec2 uv_offset = ivec2(2,2);
 const int blur_kernel_size = 16;
 
 // depth edge of accumulation of one lightprobe
-const float gi_depth_fade_distance = 2.;
+const float gi_depth_fade_distance = 3.;
 
 float normpdf2(in float x2, in float sigma) { return 0.39894*exp(-0.5*x2/(sigma*sigma))/sigma; }
 float normpdf(in float x, in float sigma) { return normpdf2(x*x, sigma); }

--- a/ref_vk/shaders/denoiser_sh.comp
+++ b/ref_vk/shaders/denoiser_sh.comp
@@ -1,0 +1,71 @@
+#version 460
+
+// This is extra blur for global illumination
+// Spherical harmonics are mixed and make soft light probes with filter by distance
+
+#include "noise.glsl"
+#include "spherical_harmonics.glsl"
+
+layout(local_size_x = 16, local_size_y = 8, local_size_z = 1) in;
+
+layout(set = 0, binding = 0, rgba16f) uniform image2D out_sh1_blured;
+layout(set = 0, binding = 1, rgba16f) uniform image2D out_sh2_blured;
+
+layout(set = 0, binding = 2, rgba16f) uniform image2D src_indirect_sh1;
+layout(set = 0, binding = 3, rgba16f) uniform image2D src_indirect_sh2;
+
+
+// offset between samples, additional bluring on compose make this way right
+// ivec2(1,1) - it'is like no offset, but it's need for larger area of collection
+const ivec2 uv_offset = ivec2(2,2);
+
+// max offset is uv_offset*blur_kernel_size, recommended ivec2(4,4) and blur_kernel_size = 8
+const int blur_kernel_size = 16;
+
+// depth edge of accumulation of one lightprobe
+const float gi_depth_fade_distance = 2.;
+
+float normpdf2(in float x2, in float sigma) { return 0.39894*exp(-0.5*x2/(sigma*sigma))/sigma; }
+float normpdf(in float x, in float sigma) { return normpdf2(x*x, sigma); }
+
+void main() {
+	ivec2 res = ivec2(imageSize(src_indirect_sh1));
+	ivec2 pix = ivec2(gl_GlobalInvocationID);
+
+	if (any(greaterThanEqual(pix, res))) {
+		return;
+	}
+
+	float depth = imageLoad(src_indirect_sh2, pix).z;
+
+	vec4 sh1 = vec4(0.);
+	vec4 sh2 = vec4(0.);
+
+	float total_scale = 0.;
+	for (int x = -blur_kernel_size; x <= blur_kernel_size; ++x)
+		for (int y = -blur_kernel_size; y <= blur_kernel_size; ++y) {
+			const ivec2 p = pix + ivec2(x, y) * uv_offset;
+			if (any(greaterThanEqual(p, res)) || any(lessThan(p, ivec2(0)))) {
+				continue;
+			}
+
+			const vec4 sh1_current = imageLoad(src_indirect_sh1, p);
+			const vec4 sh2_current = imageLoad(src_indirect_sh2, p);
+
+			const float depth_current = sh2_current.z;
+			const float scale = fade_by_depth(depth_current, depth, gi_depth_fade_distance);
+
+			sh1 += imageLoad(src_indirect_sh1, p) * scale;
+			sh2 += imageLoad(src_indirect_sh2, p) * scale;
+
+			total_scale += scale;
+		}
+
+	if (total_scale > 0.) {
+		sh1 /= total_scale;
+		sh2 /= total_scale;
+	}
+
+	imageStore(out_sh1_blured, pix, sh1);
+	imageStore(out_sh2_blured, pix, vec4(sh2.xy, depth, 0));
+}

--- a/ref_vk/shaders/denoiser_sh.comp
+++ b/ref_vk/shaders/denoiser_sh.comp
@@ -20,7 +20,7 @@ layout(set = 0, binding = 3, rgba16f) uniform image2D src_indirect_sh2;
 const ivec2 uv_offset = ivec2(2,2);
 
 // max offset is uv_offset*blur_kernel_size, recommended ivec2(4,4) and blur_kernel_size = 8
-const int blur_kernel_size = 16;
+const int blur_kernel_size = 24;
 
 // depth edge of accumulation of one lightprobe
 const float gi_depth_fade_distance = 3.;

--- a/ref_vk/shaders/ray.rgen
+++ b/ref_vk/shaders/ray.rgen
@@ -18,8 +18,8 @@ const float throughput_threshold = 1e-3;
 const float depth_multiplier = 0.01;
 
 // denoiser parameters
-const float prevous_frames_temporal_mix = 0.5;
-const float gi_depth_fade_distance = 2.;
+const float prevous_frames_temporal_mix = 0.8;
+const float gi_depth_fade_distance = 3.;
 const float indirectional_lights_clamping = 0.9;
 const float specular_reflection_clamping = 0.9;
 
@@ -621,8 +621,8 @@ void main() {
 
 	float prevous_depth = sh2_prevous.z;
 
-	low_freq.shY = sh1_prevous;
-	low_freq.CoCg = sh2_prevous.xy;
+	low_freq.shY = vec4(0.);
+	low_freq.CoCg = vec2(0.);
 
 	vec3 indirect_color = clamp_color(out_accumulated, indirectional_lights_clamping) * STORAGE_SCALE_LF;
 	//vec3 indirect_color = STORAGE_SCALE_LF * out_accumulated / color_factor;

--- a/ref_vk/shaders/ray.rgen
+++ b/ref_vk/shaders/ray.rgen
@@ -5,6 +5,7 @@
 #include "ray_kusochki.glsl"
 #include "noise.glsl"
 #include "brdf.h"
+#include "spherical_harmonics.glsl"
 
 //#define DEBUG_LIGHT_CULLING
 
@@ -14,6 +15,13 @@ const float pdf_culling_threshold = 1e6;//100.;
 const float color_factor = 1.;
 const float color_culling_threshold = 1e-6;//600./color_factor;
 const float throughput_threshold = 1e-3;
+const float depth_multiplier = 0.01;
+
+// denoiser parameters
+const float prevous_frames_temporal_mix = 0.5;
+const float gi_depth_fade_distance = 2.;
+const float indirectional_lights_clamping = 0.9;
+const float specular_reflection_clamping = 0.9;
 
 layout (constant_id = 4) const float LIGHT_GRID_CELL_SIZE = 256.;
 layout (constant_id = 5) const uint MAX_LIGHT_CLUSTERS = 32768;
@@ -32,6 +40,8 @@ layout(set = 0, binding = 9, rgba16f) uniform image2D out_image_diffuse_gi;
 layout(set = 0, binding = 10, rgba16f) uniform image2D out_image_specular;
 layout(set = 0, binding = 11, rgba16f) uniform image2D out_image_additive;
 layout(set = 0, binding = 12, rgba16f) uniform image2D out_image_normals;
+layout(set = 0, binding = 14, rgba16f) uniform image2D out_image_indirect_sh1;
+layout(set = 0, binding = 15, rgba16f) uniform image2D out_image_indirect_sh2;
 
 layout(set = 0, binding = 1) uniform accelerationStructureEXT tlas;
 layout(set = 0, binding = 2) uniform UBO {
@@ -53,6 +63,12 @@ layout (push_constant) uniform PC_ {
 layout(location = PAYLOAD_LOCATION_OPAQUE) rayPayloadEXT RayPayloadOpaque payload_opaque;
 layout(location = PAYLOAD_LOCATION_SHADOW) rayPayloadEXT RayPayloadShadow payload_shadow;
 layout(location = PAYLOAD_LOCATION_ADDITIVE) rayPayloadEXT RayPayloadAdditive payload_additive;
+
+// clamp light exposition without loosing of color
+vec3 clamp_color(vec3 color, float clamp_value) {
+	float max_color = max(max(color.r, color.g), color.b);
+	return max_color > clamp_value ? (color / max_color) * clamp_value : color;
+}
 
 bool shadowed(vec3 pos, vec3 dir, float dist) {
 	payload_shadow.hit_type = SHADOW_HIT;
@@ -419,6 +435,9 @@ void main() {
 	vec3 out_specular = vec3(0.);
 	vec3 out_base_color = vec3(0.);
 	vec4 out_normals = vec4(0.);
+	vec3 gi_direction = -direction;
+	vec3 camera_position = origin;
+	float depth = 0.;
 
 	// Can be specular or diffuse_gi based on first bounce
 	vec3 out_accumulated = vec3(0.);
@@ -497,8 +516,12 @@ void main() {
 
 			out_material_index = float(payload_opaque.material_index);
 			out_base_color = payload_opaque.base_color;
-			out_normals = vec4(geometryNormal.xy, shadingNormal.xy);
+			//out_normals = vec4(geometryNormal.xy, shadingNormal.xy);
 			payload_opaque.base_color = vec3(1.);
+
+			// world space normals stored without encoding now
+			out_normals = vec4(payload_opaque.normal, 0);
+			depth = length(camera_position - payload_opaque.hit_pos_t.xyz) * depth_multiplier;
 
 			//out_material_index = float(kusochki[payload_opaque.kusok_index].tex_roughness);
 #if 0
@@ -550,6 +573,9 @@ void main() {
 		vec3 diffuse, specular;
 		computeLighting(prev_throughput, -direction, material, diffuse, specular);
 
+		// reduction of white points 
+		//specular = clamp_color(specular, specular_reflection_clamping);
+
 		if (bounce == 0) {
 			out_diffuse_gi += diffuse;
 			out_specular += specular;
@@ -574,19 +600,48 @@ void main() {
 
 		origin = payload_opaque.hit_pos_t.xyz;
 
-		if (bounce == 0)
+		if (bounce == 0) {
 			first_bounce_brdf_type = brdfType;
+			gi_direction = direction;
+		}
 	} // for all bounces
 
-	if (first_bounce_brdf_type == DIFFUSE_TYPE) {
-		out_diffuse_gi += out_accumulated;
-	} else {
-		out_specular += out_accumulated;
-	}
+//	// global illumination stored separately now 
+//	if (first_bounce_brdf_type == DIFFUSE_TYPE) {
+//		out_diffuse_gi += out_accumulated;
+//	} else {
+//		out_specular += out_accumulated;
+//	}
+
+	SH low_freq;
+
+	// TODO: please, reproject this coords with matrices from prevous frame.....
+	vec4 sh1_prevous = imageLoad(out_image_indirect_sh1, ivec2(gl_LaunchIDEXT.xy));
+	vec4 sh2_prevous = imageLoad(out_image_indirect_sh2, ivec2(gl_LaunchIDEXT.xy));
+
+	float prevous_depth = sh2_prevous.z;
+
+	low_freq.shY = sh1_prevous;
+	low_freq.CoCg = sh2_prevous.xy;
+
+	vec3 indirect_color = clamp_color(out_accumulated, indirectional_lights_clamping) * STORAGE_SCALE_LF;
+	//vec3 indirect_color = STORAGE_SCALE_LF * out_accumulated / color_factor;
+
+	accumulate_SH(low_freq, irradiance_to_SH(indirect_color, gi_direction), 1.0);
+
+	vec4 sh1_out = low_freq.shY;
+	vec2 sh2_out = low_freq.CoCg;
+
+	float mix_weight = prevous_frames_temporal_mix * fade_by_depth(depth, prevous_depth, gi_depth_fade_distance);
+
+	sh1_out = mix(sh1_out, sh1_prevous, mix_weight);
+	sh2_out = mix(sh2_out, sh2_prevous.xy, mix_weight);
 
 	imageStore(out_image_base_color, ivec2(gl_LaunchIDEXT.xy), vec4(out_base_color, 0.));
 	imageStore(out_image_normals, ivec2(gl_LaunchIDEXT.xy), out_normals);
 	imageStore(out_image_diffuse_gi, ivec2(gl_LaunchIDEXT.xy), vec4(out_diffuse_gi / color_factor, out_material_index));
 	imageStore(out_image_specular, ivec2(gl_LaunchIDEXT.xy), vec4(out_specular / color_factor, 0.));
 	imageStore(out_image_additive, ivec2(gl_LaunchIDEXT.xy), vec4(out_additive / color_factor, 0.));
+	imageStore(out_image_indirect_sh1, ivec2(gl_LaunchIDEXT.xy), sh1_out);
+	imageStore(out_image_indirect_sh2, ivec2(gl_LaunchIDEXT.xy), vec4(sh2_out, depth, 0));
 }

--- a/ref_vk/shaders/ray.rgen
+++ b/ref_vk/shaders/ray.rgen
@@ -19,7 +19,7 @@ const float depth_multiplier = 0.01;
 
 // denoiser parameters
 const float prevous_frames_temporal_mix = 0.8;
-const float gi_depth_fade_distance = 3.;
+const float gi_depth_fade_distance = 1.0;
 const float indirectional_lights_clamping = 0.9;
 const float specular_reflection_clamping = 0.9;
 

--- a/ref_vk/shaders/ray.rgen
+++ b/ref_vk/shaders/ray.rgen
@@ -17,9 +17,9 @@ const float color_culling_threshold = 1e-6;//600./color_factor;
 const float throughput_threshold = 1e-3;
 const float depth_multiplier = 0.01;
 
-// denoiser parameters
-const float prevous_frames_temporal_mix = 0.0;
-const float gi_depth_fade_distance = 10.0;
+// denoiser parameters - temporal blur now is off
+//const float prevous_frames_temporal_mix = 0.0;
+//const float gi_depth_fade_distance = 10.0;
 const float indirectional_lights_clamping = 0.6;
 const float specular_reflection_clamping = 0.9;
 
@@ -616,10 +616,10 @@ void main() {
 	SH low_freq;
 
 	// TODO: please, reproject this coords with matrices from prevous frame.....
-	vec4 sh1_prevous = imageLoad(out_image_indirect_sh1, ivec2(gl_LaunchIDEXT.xy));
-	vec4 sh2_prevous = imageLoad(out_image_indirect_sh2, ivec2(gl_LaunchIDEXT.xy));
-
-	float prevous_depth = sh2_prevous.z;
+//	vec4 sh1_prevous = imageLoad(out_image_indirect_sh1, ivec2(gl_LaunchIDEXT.xy));
+//	vec4 sh2_prevous = imageLoad(out_image_indirect_sh2, ivec2(gl_LaunchIDEXT.xy));
+//
+//	float prevous_depth = sh2_prevous.z;
 
 	low_freq.shY = vec4(0.);
 	low_freq.CoCg = vec2(0.);
@@ -632,10 +632,10 @@ void main() {
 	vec4 sh1_out = low_freq.shY;
 	vec2 sh2_out = low_freq.CoCg;
 
-	float mix_weight = prevous_frames_temporal_mix * fade_by_depth(depth, prevous_depth, gi_depth_fade_distance);
-
-	sh1_out = mix(sh1_out, sh1_prevous, mix_weight);
-	sh2_out = mix(sh2_out, sh2_prevous.xy, mix_weight);
+//	float mix_weight = prevous_frames_temporal_mix * fade_by_depth(depth, prevous_depth, gi_depth_fade_distance);
+//
+//	sh1_out = mix(sh1_out, sh1_prevous, mix_weight);
+//	sh2_out = mix(sh2_out, sh2_prevous.xy, mix_weight);
 
 	imageStore(out_image_base_color, ivec2(gl_LaunchIDEXT.xy), vec4(out_base_color, 0.));
 	imageStore(out_image_normals, ivec2(gl_LaunchIDEXT.xy), out_normals);

--- a/ref_vk/shaders/ray.rgen
+++ b/ref_vk/shaders/ray.rgen
@@ -17,6 +17,16 @@ const float color_culling_threshold = 1e-6;//600./color_factor;
 const float throughput_threshold = 1e-3;
 const float depth_multiplier = 0.01;
 
+
+// Choose just single option to increacing perfomance:
+
+// Balance perfomance and visual
+//#define LIGHTS_QUARTER_REDUCION 1
+
+// More perfomance, but not so beautiful
+#define LIGHTS_NINEFOLD_REDUCION 1
+
+
 // denoiser parameters - temporal blur now is off
 //const float prevous_frames_temporal_mix = 0.0;
 //const float gi_depth_fade_distance = 10.0;
@@ -140,6 +150,16 @@ vec2 baryMix(vec2 v1, vec2 v2, vec2 v3, vec2 bary) {
 	return v1 * (1. - bary.x - bary.y) + v2 * bary.x + v3 * bary.y;
 }
 
+int quarterPart() {
+	ivec2 pix = ivec2(gl_LaunchIDEXT.xy) % 2;
+	return pix.x + 2 * pix.y;
+}
+
+int ninefoldPart() {
+	ivec2 pix = ivec2(gl_LaunchIDEXT.xy) % 3;
+	return pix.x + 3 * pix.y;
+}
+
 void sampleSurfaceTriangle(
 	vec3 color, vec3 view_dir, MaterialProperties material /* TODO BrdfData instead is supposedly more efficient */,
 	mat4x3 emissive_transform, mat3 emissive_transform_normal,
@@ -172,7 +192,7 @@ void sampleSurfaceTriangle(
 		return vec3(1., 0., 1.) * color_factor;
 #else
 		return;
-#endif
+#endif 
 
 	// Consider area light sources as planes, take the first normal
 	const vec3 normal = normalize(emissive_transform_normal * vertices[vi1].normal);
@@ -245,7 +265,15 @@ void sampleSurfaceTriangle(
 void computePointLights(uint cluster_index, vec3 throughput, vec3 view_dir, MaterialProperties material, out vec3 diffuse, out vec3 specular) {
 	diffuse = specular = vec3(0.);
 	const uint num_point_lights = uint(light_grid.clusters[cluster_index].num_point_lights);
+#ifdef LIGHTS_NINEFOLD_REDUCION
+	int start = ninefoldPart();
+	for (int j = start; j < num_point_lights; j += 9) {
+#elif LIGHTS_QUARTER_REDUCION
+	int start = quarterPart();
+	for (int j = start; j < num_point_lights; j += 4) {
+#else
 	for (uint j = 0; j < num_point_lights; ++j) {
+#endif
 		const uint i = uint(light_grid.clusters[cluster_index].point_lights[j]);
 
 		vec3 color = lights.point_lights[i].color_stopdot.rgb * throughput;
@@ -348,17 +376,27 @@ void computeLighting(vec3 throughput, vec3 view_dir, MaterialProperties material
 
 	const uint num_emissive_kusochki = uint(light_grid.clusters[cluster_index].num_emissive_surfaces);
 	float sampling_light_scale = 1.;
-#if 0
-	const uint max_lights_per_frame = 4;
-	uint begin_i = 0, end_i = num_emissive_kusochki;
-	if (end_i > max_lights_per_frame) {
-		begin_i = rand() % (num_emissive_kusochki - max_lights_per_frame);
-		end_i = begin_i + max_lights_per_frame;
-		sampling_light_scale = float(num_emissive_kusochki) / float(max_lights_per_frame);
-	}
-	for (uint i = begin_i; i < end_i; ++i) {
-#else
+//#if 0
+//	const uint max_lights_per_frame = 4;
+//	uint begin_i = 0, end_i = num_emissive_kusochki;
+//	if (end_i > max_lights_per_frame) {
+//		begin_i = rand() % (num_emissive_kusochki - max_lights_per_frame);
+//		end_i = begin_i + max_lights_per_frame;
+//		sampling_light_scale = float(num_emissive_kusochki) / float(max_lights_per_frame);
+//	}
+//	for (uint i = begin_i; i < end_i; ++i) {
+//#else
+//
+//	for (uint i = 0; i < num_emissive_kusochki; ++i) {
+//#endif
 
+#ifdef LIGHTS_NINEFOLD_REDUCION
+	int start = ninefoldPart();
+	for (int i = start; i < num_emissive_kusochki; i += 9) {
+#elif LIGHTS_QUARTER_REDUCION
+	int start = quarterPart();
+	for (int i = start; i < num_emissive_kusochki; i += 4) {
+#else
 	for (uint i = 0; i < num_emissive_kusochki; ++i) {
 #endif
 		const uint index_into_emissive_kusochki = uint(light_grid.clusters[cluster_index].emissive_surfaces[i]);
@@ -613,6 +651,15 @@ void main() {
 //		out_specular += out_accumulated;
 //	}
 
+
+#ifdef LIGHTS_NINEFOLD_REDUCION
+	out_diffuse_gi *= 9.;
+	out_specular *= 9.;
+#elif LIGHTS_QUARTER_REDUCION
+	out_diffuse_gi *= 4.;
+	out_specular *= 4.;
+#endif
+
 	SH low_freq;
 
 	// TODO: please, reproject this coords with matrices from prevous frame.....
@@ -626,6 +673,12 @@ void main() {
 
 	vec3 indirect_color = clamp_color(out_accumulated, indirectional_lights_clamping) * STORAGE_SCALE_LF;
 	//vec3 indirect_color = STORAGE_SCALE_LF * out_accumulated / color_factor;
+
+#ifdef LIGHTS_NINEFOLD_REDUCION
+	indirect_color *= 9.;
+#elif LIGHTS_QUARTER_REDUCION
+	indirect_color *= 4.;
+#endif
 
 	accumulate_SH(low_freq, irradiance_to_SH(indirect_color, gi_direction), 1.0);
 

--- a/ref_vk/shaders/ray.rgen
+++ b/ref_vk/shaders/ray.rgen
@@ -18,9 +18,9 @@ const float throughput_threshold = 1e-3;
 const float depth_multiplier = 0.01;
 
 // denoiser parameters
-const float prevous_frames_temporal_mix = 0.8;
-const float gi_depth_fade_distance = 1.0;
-const float indirectional_lights_clamping = 0.9;
+const float prevous_frames_temporal_mix = 0.0;
+const float gi_depth_fade_distance = 10.0;
+const float indirectional_lights_clamping = 0.6;
 const float specular_reflection_clamping = 0.9;
 
 layout (constant_id = 4) const float LIGHT_GRID_CELL_SIZE = 256.;

--- a/ref_vk/shaders/spherical_harmonics.glsl
+++ b/ref_vk/shaders/spherical_harmonics.glsl
@@ -1,0 +1,97 @@
+// Copypasted from Quake 2 RTX
+// https://github.com/NVIDIA/Q2RTX
+//
+// Original licence code:
+//
+//	Copyright (C) 2018 Christoph Schied
+//	Copyright (C) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+//	This program is free software; you can redistribute it and/or modify
+//	it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation; either version 2 of the License, or
+//	(at your option) any later version.
+//
+//	This program is distributed in the hope that it will be useful,
+//	but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//	GNU General Public License for more details.
+//
+//	You should have received a copy of the GNU General Public License along
+//	with this program; if not, write to the Free Software Foundation, Inc.,
+//	51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+
+#define STORAGE_SCALE_LF 1024.0
+
+struct SH
+{
+    vec4 shY;
+    vec2 CoCg;
+};
+
+vec3 project_SH_irradiance(SH sh, vec3 N)
+{
+    float d = dot(sh.shY.xyz, N);
+    float Y = 2.0 * (1.023326 * d + 0.886226 * sh.shY.w);
+    Y = max(Y, 0.0);
+
+    sh.CoCg *= Y * 0.282095 / (sh.shY.w + 1e-6);
+
+    float   T       = Y - sh.CoCg.y * 0.5;
+    float   G       = sh.CoCg.y + T;
+    float   B       = T - sh.CoCg.x * 0.5;
+    float   R       = B + sh.CoCg.x;
+
+    return max(vec3(R, G, B), vec3(0.0));
+}
+
+SH irradiance_to_SH(vec3 color, vec3 dir)
+{
+    SH result;
+
+    float   Co      = color.r - color.b;
+    float   t       = color.b + Co * 0.5;
+    float   Cg      = color.g - t;
+    float   Y       = max(t + Cg * 0.5, 0.0);
+
+    result.CoCg = vec2(Co, Cg);
+
+    float   L00     = 0.282095;
+    float   L1_1    = 0.488603 * dir.y;
+    float   L10     = 0.488603 * dir.z;
+    float   L11     = 0.488603 * dir.x;
+
+    result.shY = vec4 (L11, L1_1, L10, L00) * Y;
+
+    return result;
+}
+
+vec3 SH_to_irradiance(SH sh)
+{
+    float   Y       = sh.shY.w / 0.282095;
+
+    float   T       = Y - sh.CoCg.y * 0.5;
+    float   G       = sh.CoCg.y + T;
+    float   B       = T - sh.CoCg.x * 0.5;
+    float   R       = B + sh.CoCg.x;
+
+    return max(vec3(R, G, B), vec3(0.0));
+}
+
+void accumulate_SH(inout SH accum, SH b, float scale)
+{
+    accum.shY += b.shY * scale;
+    accum.CoCg += b.CoCg * scale;
+}
+
+SH mix_SH(SH a, SH b, float s)
+{
+    SH result;
+    result.shY = mix(a.shY, b.shY, vec4(s));
+    result.CoCg = mix(a.CoCg, b.CoCg, vec2(s));
+    return result;
+}
+
+float fade_by_depth(float depthA, float depthB, float max_offset) {
+	return 1. - smoothstep(0., max_offset, abs(depthA - depthB));
+}

--- a/ref_vk/vk_denoiser.c
+++ b/ref_vk/vk_denoiser.c
@@ -13,8 +13,20 @@ enum {
 	DenoiserBinding_Source_Specular = 3,
 	DenoiserBinding_Source_Additive = 4,
 	DenoiserBinding_Source_Normals = 5,
+	DenoiserBinding_Source_SH1 = 6,
+	DenoiserBinding_Source_SH2 = 7,
 
 	DenoiserBinding_COUNT
+};
+
+enum {
+	DenoiserSH_Binding_SH1_DestImage = 0,
+	DenoiserSH_Binding_SH2_DestImage = 1,
+
+	DenoiserSH_Binding_SH1_Source = 2,
+	DenoiserSH_Binding_SH2_Source = 3,
+
+	DenoiserSH_Binding_COUNT
 };
 
 static struct {
@@ -25,9 +37,19 @@ static struct {
 	VkDescriptorSet desc_sets[1];
 
 	VkPipeline pipeline;
-} g_denoiser = {0};
+} g_denoiser = { 0 };
 
-static void createLayouts( void ) {
+static struct {
+	vk_descriptors_t descriptors;
+	vk_descriptor_value_t desc_values[DenoiserSH_Binding_COUNT];
+
+	VkDescriptorSetLayoutBinding desc_bindings[DenoiserSH_Binding_COUNT];
+	VkDescriptorSet desc_sets[1];
+
+	VkPipeline pipeline;
+} g_denoiser_sh = { 0 };
+
+static void createLayouts(void) {
 	g_denoiser.descriptors.bindings = g_denoiser.desc_bindings;
 	g_denoiser.descriptors.num_bindings = ARRAYSIZE(g_denoiser.desc_bindings);
 	g_denoiser.descriptors.values = g_denoiser.desc_values;
@@ -81,20 +103,88 @@ static void createLayouts( void ) {
 		.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT,
 	};
 
+	g_denoiser.desc_bindings[DenoiserBinding_Source_SH1] = (VkDescriptorSetLayoutBinding){
+		.binding = DenoiserBinding_Source_SH1,
+		.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+		.descriptorCount = 1,
+		.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT,
+	};
+
+	g_denoiser.desc_bindings[DenoiserBinding_Source_SH2] = (VkDescriptorSetLayoutBinding){
+		.binding = DenoiserBinding_Source_SH2,
+		.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+		.descriptorCount = 1,
+		.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT,
+	};
+
 	VK_DescriptorsCreate(&g_denoiser.descriptors);
 }
 
-static VkPipeline createPipeline( void ) {
+
+static void createLayoutsSH(void) {
+	g_denoiser_sh.descriptors.bindings = g_denoiser_sh.desc_bindings;
+	g_denoiser_sh.descriptors.num_bindings = ARRAYSIZE(g_denoiser_sh.desc_bindings);
+	g_denoiser_sh.descriptors.values = g_denoiser_sh.desc_values;
+	g_denoiser_sh.descriptors.num_sets = 1;
+	g_denoiser_sh.descriptors.desc_sets = g_denoiser_sh.desc_sets;
+	g_denoiser_sh.descriptors.push_constants = (VkPushConstantRange){
+		.offset = 0,
+		.size = 0,
+		.stageFlags = 0,
+	};
+
+	g_denoiser_sh.desc_bindings[DenoiserSH_Binding_SH1_DestImage] = (VkDescriptorSetLayoutBinding){
+		.binding = DenoiserSH_Binding_SH1_DestImage,
+		.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+		.descriptorCount = 1,
+		.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT,
+	};
+
+	g_denoiser_sh.desc_bindings[DenoiserSH_Binding_SH2_DestImage] = (VkDescriptorSetLayoutBinding){
+		.binding = DenoiserSH_Binding_SH2_DestImage,
+		.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+		.descriptorCount = 1,
+		.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT,
+	};
+
+	g_denoiser_sh.desc_bindings[DenoiserSH_Binding_SH1_Source] = (VkDescriptorSetLayoutBinding){
+		.binding = DenoiserSH_Binding_SH1_Source,
+		.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+		.descriptorCount = 1,
+		.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT,
+	};
+
+	g_denoiser_sh.desc_bindings[DenoiserSH_Binding_SH2_Source] = (VkDescriptorSetLayoutBinding){
+		.binding = DenoiserSH_Binding_SH2_Source,
+		.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+		.descriptorCount = 1,
+		.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT,
+	};
+
+	VK_DescriptorsCreate(&g_denoiser_sh.descriptors);
+}
+
+static VkPipeline createPipeline(void) {
 	const vk_pipeline_compute_create_info_t pcci = {
 		.layout = g_denoiser.descriptors.pipeline_layout,
 		.shader_filename = "denoiser.comp.spv",
 		.specialization_info = NULL,
 	};
 
-	return VK_PipelineComputeCreate( &pcci );
+	return VK_PipelineComputeCreate(&pcci);
 }
 
-qboolean XVK_DenoiserInit( void ) {
+static VkPipeline createPipelineSH(void) {
+	const vk_pipeline_compute_create_info_t pcci = {
+		.layout = g_denoiser_sh.descriptors.pipeline_layout,
+		.shader_filename = "denoiser_sh.comp.spv",
+		.specialization_info = NULL,
+	};
+
+	return VK_PipelineComputeCreate(&pcci);
+}
+
+qboolean XVK_DenoiserInit(void) {
 	ASSERT(vk_core.rtx);
 
 	createLayouts();
@@ -102,26 +192,75 @@ qboolean XVK_DenoiserInit( void ) {
 	ASSERT(!g_denoiser.pipeline);
 	g_denoiser.pipeline = createPipeline();
 
-	return g_denoiser.pipeline != VK_NULL_HANDLE;
+	createLayoutsSH();
+
+	ASSERT(!g_denoiser_sh.pipeline);
+	g_denoiser_sh.pipeline = createPipelineSH();
+
+	return g_denoiser.pipeline != VK_NULL_HANDLE && g_denoiser_sh.pipeline != VK_NULL_HANDLE;
 }
 
-void XVK_DenoiserDestroy( void ) {
+void XVK_DenoiserDestroy(void) {
 	ASSERT(vk_core.rtx);
 	ASSERT(g_denoiser.pipeline);
 
 	vkDestroyPipeline(vk_core.device, g_denoiser.pipeline, NULL);
 	VK_DescriptorsDestroy(&g_denoiser.descriptors);
+
+	ASSERT(g_denoiser_sh.pipeline);
+
+	vkDestroyPipeline(vk_core.device, g_denoiser_sh.pipeline, NULL);
+	VK_DescriptorsDestroy(&g_denoiser_sh.descriptors);
 }
 
-void XVK_DenoiserReloadPipeline( void ) {
+void XVK_DenoiserReloadPipeline(void) {
 	// TODO handle errors gracefully
 	vkDestroyPipeline(vk_core.device, g_denoiser.pipeline, NULL);
 	g_denoiser.pipeline = createPipeline();
+
+	vkDestroyPipeline(vk_core.device, g_denoiser_sh.pipeline, NULL);
+	g_denoiser_sh.pipeline = createPipelineSH();
 }
 
-void XVK_DenoiserDenoise( const xvk_denoiser_args_t* args ) {
+void XVK_DenoiserDenoise(const xvk_denoiser_args_t* args) {
 	const uint32_t WG_W = 16;
 	const uint32_t WG_H = 8;
+
+
+	// Create spherical harmonics from directions and colors of indirectional lighting
+
+	g_denoiser_sh.desc_values[DenoiserSH_Binding_SH1_Source].image = (VkDescriptorImageInfo){
+		.sampler = VK_NULL_HANDLE,
+		.imageView = args->src.indirect_sh1_view,
+		.imageLayout = VK_IMAGE_LAYOUT_GENERAL,
+	};
+
+	g_denoiser_sh.desc_values[DenoiserSH_Binding_SH2_Source].image = (VkDescriptorImageInfo){
+		.sampler = VK_NULL_HANDLE,
+		.imageView = args->src.indirect_sh2_view,
+		.imageLayout = VK_IMAGE_LAYOUT_GENERAL,
+	};
+
+	g_denoiser_sh.desc_values[DenoiserSH_Binding_SH1_DestImage].image = (VkDescriptorImageInfo){
+		.sampler = VK_NULL_HANDLE,
+		.imageView = args->sh1_blured_view,
+		.imageLayout = VK_IMAGE_LAYOUT_GENERAL,
+	};
+
+	g_denoiser_sh.desc_values[DenoiserSH_Binding_SH2_DestImage].image = (VkDescriptorImageInfo){
+		.sampler = VK_NULL_HANDLE,
+		.imageView = args->sh2_blured_view,
+		.imageLayout = VK_IMAGE_LAYOUT_GENERAL,
+	};
+
+	VK_DescriptorsWrite(&g_denoiser_sh.descriptors);
+
+	vkCmdBindPipeline(args->cmdbuf, VK_PIPELINE_BIND_POINT_COMPUTE, g_denoiser_sh.pipeline);
+	vkCmdBindDescriptorSets(args->cmdbuf, VK_PIPELINE_BIND_POINT_COMPUTE, g_denoiser_sh.descriptors.pipeline_layout, 0, 1, g_denoiser_sh.descriptors.desc_sets + 0, 0, NULL);
+	vkCmdDispatch(args->cmdbuf, (args->width + WG_W - 1) / WG_W, (args->height + WG_H - 1) / WG_H, 1);
+
+
+	// Compose with blur and relighting by spherical harmonics
 
 	g_denoiser.desc_values[DenoiserBinding_Source_BaseColor].image = (VkDescriptorImageInfo){
 		.sampler = VK_NULL_HANDLE,
@@ -150,6 +289,18 @@ void XVK_DenoiserDenoise( const xvk_denoiser_args_t* args ) {
 	g_denoiser.desc_values[DenoiserBinding_Source_Normals].image = (VkDescriptorImageInfo){
 		.sampler = VK_NULL_HANDLE,
 		.imageView = args->src.normals_view,
+		.imageLayout = VK_IMAGE_LAYOUT_GENERAL,
+	};
+
+	g_denoiser.desc_values[DenoiserBinding_Source_SH1].image = (VkDescriptorImageInfo){
+		.sampler = VK_NULL_HANDLE,
+		.imageView = args->sh1_blured_view,
+		.imageLayout = VK_IMAGE_LAYOUT_GENERAL,
+	};
+
+	g_denoiser.desc_values[DenoiserBinding_Source_SH2].image = (VkDescriptorImageInfo){
+		.sampler = VK_NULL_HANDLE,
+		.imageView = args->sh2_blured_view,
 		.imageLayout = VK_IMAGE_LAYOUT_GENERAL,
 	};
 

--- a/ref_vk/vk_denoiser.h
+++ b/ref_vk/vk_denoiser.h
@@ -17,8 +17,12 @@ typedef struct {
 		VkImageView specular_view;
 		VkImageView additive_view;
 		VkImageView normals_view;
+		VkImageView indirect_sh1_view;
+		VkImageView indirect_sh2_view;
 	} src;
 
+	VkImageView sh1_blured_view;
+	VkImageView sh2_blured_view;
 	VkImageView dst_view;
 } xvk_denoiser_args_t;
 


### PR DESCRIPTION
Code of spherical harmonics get from Quake 2 RTX

And little bit of temporal filtering. in future, we can reproject this by camera matrices. Just put them to ray.rgen and correct coordinates of sampling of prevous frame. Spherical harmonics works in world coordinate system and have buff to rotations