### PR TITLE
vk: ring-based dynamic geometry buf alloc

### DIFF
--- a/ref_vk/TODO.md
+++ b/ref_vk/TODO.md
@@ -1,3 +1,24 @@
+# Parallel frames
+- [ ] allocate for N frames:
+	- [x] geometries
+	- [ ] rt models
+	- [ ] lights
+
+// O. 1 buffer i bardak v nyom
+// - [SSSSAAS.SBAS....]
+// - can become extremely fragmented
+
+// I. 2 buffer + bit indirection
+// - lives longer than 2 frames [SSS.SSS..SS.....]
+// - dynamic [AAAAA->.....<-BBBBBB]
+// - high bits in shader point to buffer
+
+// II. 1 buffer bi-directional
+// - [SSS.SS..S...|AAAABBBB->...]
+//    ^ - long-living "static" stuff
+//                 ^ - dynamic ring buffer
+// - [SSS.SS..S.|.....<-AAAABBBB] (dynamic split)
+
 # Passes
 - [ ] better simple sampling
 	- [x] all triangles

--- a/ref_vk/alolcator.h
+++ b/ref_vk/alolcator.h
@@ -17,3 +17,21 @@ typedef struct {
 
 alo_block_t aloPoolAllocate(struct alo_pool_s*, alo_size_t size, alo_size_t alignment);
 void aloPoolFree(struct alo_pool_s *pool, int index);
+
+//  <-          size          ->
+// [.....|AAAAAAAAAAAAAAA|......]
+//        ^ -- tail       ^ -- head
+typedef struct {
+	uint32_t size, head, tail;
+} alo_ring_t;
+
+#define ALO_ALLOC_FAILED 0xffffffffu
+
+// Marks the entire buffer as free
+void aloRingInit(alo_ring_t* ring, uint32_t size);
+
+// Allocates a new aligned region and returns offset to it (AllocFailed if allocation failed)
+uint32_t aloRingAlloc(alo_ring_t* ring, uint32_t size, uint32_t alignment);
+
+// Marks everything up-to-pos as free (expects up-to-pos to be valid)
+void aloRingFree(alo_ring_t* ring, uint32_t up_to_pos);

--- a/ref_vk/vk_beams.c
+++ b/ref_vk/vk_beams.c
@@ -223,7 +223,7 @@ static void R_DrawSegs( vec3_t source, vec3_t delta, float width, float scale, f
 	total_indices = (total_vertices - 2) * 3; // STRIP unrolled into LIST (TODO get rid of this)
 	ASSERT(total_vertices < UINT16_MAX );
 
-	if (!R_GeometryBufferAllocAndLock( &buffer, total_vertices, total_indices )) {
+	if (!R_GeometryBufferAllocAndLock( &buffer, total_vertices, total_indices, LifetimeSingleFrame )) {
 		gEngine.Con_Printf(S_ERROR "Cannot allocate geometry for beam\n");
 		return;
 	}

--- a/ref_vk/vk_brush.c
+++ b/ref_vk/vk_brush.c
@@ -115,7 +115,7 @@ static void EmitWaterPolys( const cl_entity_t *ent, const msurface_t *warp, qboo
 		num_indices += triangles * 3;
 	}
 
-	if (!R_GeometryBufferAllocAndLock( &buffer, num_vertices, num_indices )) {
+	if (!R_GeometryBufferAllocAndLock( &buffer, num_vertices, num_indices, LifetimeSingleFrame )) {
 		gEngine.Con_Printf(S_ERROR "Cannot allocate geometry for %s\n", ent->model->name );
 		return;
 	}
@@ -485,7 +485,7 @@ static qboolean loadBrushSurfaces( model_sizes_t sizes, const model_t *mod ) {
 	uint32_t index_offset = 0;
 	r_geometry_buffer_lock_t buffer;
 
-	if (!R_GeometryBufferAllocAndLock( &buffer, sizes.num_vertices, sizes.num_indices )) {
+	if (!R_GeometryBufferAllocAndLock( &buffer, sizes.num_vertices, sizes.num_indices, LifetimeLong )) {
 		gEngine.Con_Printf(S_ERROR "Cannot allocate geometry for %s\n", mod->name );
 		return false;
 	}

--- a/ref_vk/vk_const.h
+++ b/ref_vk/vk_const.h
@@ -5,10 +5,6 @@
 
 #define MAX_TEXTURES	4096
 
-// TODO count these properly
-#define MAX_BUFFER_VERTICES (512 * 1024)
-#define MAX_BUFFER_INDICES (MAX_BUFFER_VERTICES * 3)
-
 // indexed by uint8_t
 #define MAX_SURFACE_LIGHTS 256
 // indexed by uint8_t

--- a/ref_vk/vk_framectl.c
+++ b/ref_vk/vk_framectl.c
@@ -328,12 +328,6 @@ static void submit( VkCommandBuffer cmdbuf, qboolean wait ) {
 		}
 		g_frame.current.phase = Phase_Idle;
 	}
-
-	// TODO better sync implies multiple frames in flight, which means that we must
-	// retain temporary (SingleFrame) buffer contents for longer, until all users are done.
-	// (this probably means that we should really have some kind of refcount going on...)
-	// For now we can just erase these buffers now because of sync with fence
-	XVK_RenderBufferFrameClear();
 }
 
 inline static VkCommandBuffer currentCommandBuffer( void ) {

--- a/ref_vk/vk_render.h
+++ b/ref_vk/vk_render.h
@@ -45,14 +45,16 @@ typedef struct {
 	} impl_;
 } r_geometry_buffer_lock_t;
 
-qboolean R_GeometryBufferAllocAndLock( r_geometry_buffer_lock_t *lock, int vertex_count, int index_count );
+typedef enum {
+	LifetimeLong,
+	LifetimeSingleFrame
+} r_geometry_lifetime_t;
+
+qboolean R_GeometryBufferAllocAndLock( r_geometry_buffer_lock_t *lock, int vertex_count, int index_count, r_geometry_lifetime_t lifetime );
 void R_GeometryBufferUnlock( const r_geometry_buffer_lock_t *lock );
 //void R_VkGeometryBufferFree( int handle );
 
-void XVK_RenderBufferMapFreeze( void ); // Permanently freeze all allocations as map-permanent
 void XVK_RenderBufferMapClear( void ); // Free the entire buffer for a new map
-
-void XVK_RenderBufferFrameClear( /*int frame_id*/void ); // mark data for frame with given id as free (essentially, just forward the ring buffer)
 
 void XVK_RenderBufferPrintStats( void );
 
@@ -138,14 +140,9 @@ qboolean VK_RenderModelInit( VkCommandBuffer cmdbuf, vk_render_model_t* model );
 void VK_RenderModelDestroy( vk_render_model_t* model );
 void VK_RenderModelDraw( const cl_entity_t *ent, vk_render_model_t* model );
 
-void VK_RenderFrameBegin( void );
-
 void VK_RenderModelDynamicBegin( int render_mode, const char *debug_name_fmt, ... );
 void VK_RenderModelDynamicAddGeometry( const vk_render_geometry_t *geom );
 void VK_RenderModelDynamicCommit( void );
-
-void VK_RenderFrameEnd( VkCommandBuffer cmdbuf );
-void VK_RenderFrameEndRTX( VkCommandBuffer cmdbuf, VkImageView img_dst_view, VkImage img_dst, uint32_t w, uint32_t h );
 
 void VK_RenderDebugLabelBegin( const char *label );
 void VK_RenderDebugLabelEnd( void );

--- a/ref_vk/vk_scene.c
+++ b/ref_vk/vk_scene.c
@@ -234,7 +234,6 @@ void R_NewMap( void ) {
 
 	// TODO should we do something like VK_BrushEndLoad?
 	VK_UploadLightmap();
-	XVK_RenderBufferMapFreeze();
 	XVK_RenderBufferPrintStats();
 	if (vk_core.rtx)
 		VK_RayMapLoadEnd();

--- a/ref_vk/vk_sprite.c
+++ b/ref_vk/vk_sprite.c
@@ -652,7 +652,7 @@ static void R_DrawSpriteQuad( const char *debug_name, mspriteframe_t *frame, vec
 
 	// Get buffer region for vertices and indices
 	r_geometry_buffer_lock_t buffer;
-	if (!R_GeometryBufferAllocAndLock( &buffer, 4, 6 )) {
+	if (!R_GeometryBufferAllocAndLock( &buffer, 4, 6, LifetimeSingleFrame )) {
 		gEngine.Con_Printf(S_ERROR "Cannot allocate geometry for sprite quad\n");
 		return;
 	}

--- a/ref_vk/vk_studio.c
+++ b/ref_vk/vk_studio.c
@@ -1923,7 +1923,7 @@ static void R_StudioDrawNormalMesh( short *ptricmds, vec3_t *pstudionorms, float
 	ASSERT(num_indices > 0);
 
 	// Get buffer region for vertices and indices
-	if (!R_GeometryBufferAllocAndLock( &buffer, num_vertices, num_indices )) {
+	if (!R_GeometryBufferAllocAndLock( &buffer, num_vertices, num_indices, LifetimeSingleFrame )) {
 		gEngine.Con_Printf(S_ERROR "Cannot allocate geometry for studio model\n");
 		return;
 	}

--- a/ref_vk/wscript
+++ b/ref_vk/wscript
@@ -65,6 +65,17 @@ def configure(conf):
 	if '-Werror=declaration-after-statement' in conf.env.CFLAGS:
 		conf.env.CFLAGS.remove('-Werror=declaration-after-statement')
 
+def printTestSummary(bld):
+	results = getattr(bld, 'utest_results', [])
+	for (f, code, out, err) in results:
+		if code == 0:
+			Logs.pprint('GREEN', '%s: ok' % f)
+			continue
+
+		Logs.pprint('RED', '%s: test failed' % f)
+		Logs.pprint('CYAN', out.decode('utf-8'))
+		Logs.pprint('CYAN', err.decode('utf-8'))
+
 def build(bld):
 	if not bld.env.VK:
 		return
@@ -127,3 +138,9 @@ def build(bld):
 					  bld.path.ant_glob('data/**'),
 					  cwd=bld.path.find_dir('data/'),
 					  relative_trick=True)
+
+	bld.program(features='test', defines=['ALOLCATOR_TEST'],source='alolcator.c', target='alolcator')
+	bld.add_post_fun(printTestSummary)
+
+	#from waflib.Tools import waf_unit_test
+	#bld.add_post_fun(waf_unit_test.summary)


### PR DESCRIPTION
- Clear split between static and dynamic geometry within the same buffer
- Store previous frame geometry data longer
- Use simpler ring buffer for allocation
- Add waf unit tests for alolcator

Known issues:
- ray tracing still glitches a lot