### PR TITLE
Upload only dirty light clusters regions

### DIFF
--- a/ref_vk/shaders/light.glsl
+++ b/ref_vk/shaders/light.glsl
@@ -1,6 +1,6 @@
 layout (set = 0, binding = BINDING_LIGHTS) readonly buffer SBOLights { LightsMetadata m; } lights;
 layout (set = 0, binding = BINDING_LIGHT_CLUSTERS, align = 1) readonly buffer UBOLightClusters {
-	ivec3 grid_min, grid_size;
+	//ivec3 grid_min, grid_size;
 	//uint8_t clusters_data[MAX_LIGHT_CLUSTERS * LIGHT_CLUSTER_SIZE + HACK_OFFSET];
 	LightCluster clusters_[MAX_LIGHT_CLUSTERS];
 } light_grid;
@@ -25,11 +25,11 @@ void computePointLights(vec3 P, vec3 N, uint cluster_index, vec3 throughput, vec
 	diffuse = specular = vec3(0.);
 
 	//diffuse = vec3(1.);//float(lights.m.num_point_lights) / 64.);
-//#define USE_CLUSTERS
+#define USE_CLUSTERS
 #ifdef USE_CLUSTERS
-	const uint num_point_lights = uint(light_grid.clusters[cluster_index].num_point_lights);
+	const uint num_point_lights = uint(light_grid.clusters_[cluster_index].num_point_lights);
 	for (uint j = 0; j < num_point_lights; ++j) {
-		const uint i = uint(light_grid.clusters[cluster_index].point_lights[j]);
+		const uint i = uint(light_grid.clusters_[cluster_index].point_lights[j]);
 #else
 	for (uint i = 0; i < lights.m.num_point_lights; ++i) {
 #endif
@@ -116,11 +116,11 @@ void computePointLights(vec3 P, vec3 N, uint cluster_index, vec3 throughput, vec
 void computeLighting(vec3 P, vec3 N, vec3 throughput, vec3 view_dir, MaterialProperties material, out vec3 diffuse, out vec3 specular) {
 	diffuse = specular = vec3(0.);
 
-	const ivec3 light_cell = ivec3(floor(P / LIGHT_GRID_CELL_SIZE)) - light_grid.grid_min;
-	const uint cluster_index = uint(dot(light_cell, ivec3(1, light_grid.grid_size.x, light_grid.grid_size.x * light_grid.grid_size.y)));
+	const ivec3 light_cell = ivec3(floor(P / LIGHT_GRID_CELL_SIZE)) - lights.m.grid_min_cell;
+	const uint cluster_index = uint(dot(light_cell, ivec3(1, lights.m.grid_size.x, lights.m.grid_size.x * lights.m.grid_size.y)));
 
 #ifdef USE_CLUSTERS
-	if (any(greaterThanEqual(light_cell, light_grid.grid_size)) || cluster_index >= MAX_LIGHT_CLUSTERS)
+	if (any(greaterThanEqual(light_cell, lights.m.grid_size)) || cluster_index >= MAX_LIGHT_CLUSTERS)
 		return; // throughput * vec3(1., 0., 0.);
 #endif
 

--- a/ref_vk/shaders/light_polygon.glsl
+++ b/ref_vk/shaders/light_polygon.glsl
@@ -191,12 +191,12 @@ void sampleSinglePolygonLight(in vec3 P, in vec3 N, in vec3 view_dir, in SampleC
 #if 0
 // Sample random one
 void sampleEmissiveSurfaces(vec3 P, vec3 N, vec3 throughput, vec3 view_dir, MaterialProperties material, uint cluster_index, inout vec3 diffuse, inout vec3 specular) {
-	const uint num_polygons = uint(light_grid.clusters[cluster_index].num_polygons);
+	const uint num_polygons = uint(light_grid.clusters_[cluster_index].num_polygons);
 
 	if (num_polygons == 0)
 		return;
 
-	const uint selected = uint(light_grid.clusters[cluster_index].polygons[rand_range(num_polygons)]);
+	const uint selected = uint(light_grid.clusters_[cluster_index].polygons[rand_range(num_polygons)]);
 
 	const PolygonLight poly = lights.m.polygons[selected];
 	const SampleContext ctx = buildSampleContext(P, N, view_dir);
@@ -212,11 +212,11 @@ void sampleEmissiveSurfaces(vec3 P, vec3 N, vec3 throughput, vec3 view_dir, Mate
 #if DO_ALL_IN_CLUSTER
 	const SampleContext ctx = buildSampleContext(P, N, view_dir);
 
-//#define USE_CLUSTERS
+#define USE_CLUSTERS
 #ifdef USE_CLUSTERS
-	const uint num_polygons = uint(light_grid.clusters[cluster_index].num_polygons);
+	const uint num_polygons = uint(light_grid.clusters_[cluster_index].num_polygons);
 	for (uint i = 0; i < num_polygons; ++i) {
-		const uint index = uint(light_grid.clusters[cluster_index].polygons[i]);
+		const uint index = uint(light_grid.clusters_[cluster_index].polygons[i]);
 #else
 	for (uint index = 0; index < lights.m.num_polygons; ++index) {
 #endif
@@ -257,7 +257,7 @@ void sampleEmissiveSurfaces(vec3 P, vec3 N, vec3 throughput, vec3 view_dir, Mate
 
 #ifdef USE_CLUSTERS
 	// TODO move this to pickPolygonLight function
-	const uint num_polygons = uint(light_grid.clusters[cluster_index].num_polygons);
+	const uint num_polygons = uint(light_grid.clusters_[cluster_index].num_polygons);
 #else
 	const uint num_polygons = lights.m.num_polygons;
 #endif
@@ -267,7 +267,7 @@ void sampleEmissiveSurfaces(vec3 P, vec3 N, vec3 throughput, vec3 view_dir, Mate
 	float eps1 = rand01();
 	for (uint i = 0; i < num_polygons; ++i) {
 #ifdef USE_CLUSTERS
-		const uint index = uint(light_grid.clusters[cluster_index].polygons[i]);
+		const uint index = uint(light_grid.clusters_[cluster_index].polygons[i]);
 #else
 		const uint index = i;
 #endif

--- a/ref_vk/shaders/ray_interop.h
+++ b/ref_vk/shaders/ray_interop.h
@@ -21,6 +21,7 @@
 #define vec3 vec3_t
 #define vec4 vec4_t
 #define mat4 matrix4x4
+typedef int ivec3[3];
 #define TOKENPASTE(x, y) x ## y
 #define TOKENPASTE2(x, y) TOKENPASTE(x, y)
 #define PAD(x) float TOKENPASTE2(pad_, __LINE__)[x];
@@ -111,6 +112,10 @@ struct LightsMetadata {
 	uint num_polygons;
 	uint num_point_lights;
 	PAD(2)
+	ivec3 grid_min_cell;
+	PAD(1)
+	ivec3 grid_size;
+	PAD(1)
 	STRUCT PointLight point_lights[MAX_POINT_LIGHTS];
 	STRUCT PolygonLight polygons[MAX_EMISSIVE_KUSOCHKI];
 	vec4 polygon_vertices[MAX_EMISSIVE_KUSOCHKI * 7]; // vec3 but aligned

--- a/ref_vk/vk_framectl.c
+++ b/ref_vk/vk_framectl.c
@@ -11,6 +11,9 @@
 #include "vk_staging.h"
 #include "vk_commandpool.h"
 
+#include "vk_light.h" // For stats
+#include "shaders/ray_interop.h" // stats: struct LightCluster
+
 #include "profiler.h"
 
 #include "eiface.h" // ARRAYSIZE
@@ -182,8 +185,13 @@ static void updateGamma( void ) {
 	}
 }
 
-// FIXME move this to r print speeds or something like that
+// FIXME move this to r_speeds or something like that
 static void showProfilingData( void ) {
+	{
+		const int dirty = g_lights.stats.dirty_cells;
+		gEngine.Con_NPrintf(4, "Dirty light cells: %d, estimated size = %dKiB\n", dirty, (int)(dirty * sizeof(struct LightCluster) / 1024));
+	}
+
 	gEngine.Con_NPrintf(5, "Perf scopes:");
 	for (int i = 0; i < g_aprof.num_scopes; ++i) {
 		const aprof_scope_t *const scope = g_aprof.scopes + i;

--- a/ref_vk/vk_framectl.c
+++ b/ref_vk/vk_framectl.c
@@ -189,7 +189,7 @@ static void updateGamma( void ) {
 static void showProfilingData( void ) {
 	{
 		const int dirty = g_lights.stats.dirty_cells;
-		gEngine.Con_NPrintf(4, "Dirty light cells: %d, estimated size = %dKiB\n", dirty, (int)(dirty * sizeof(struct LightCluster) / 1024));
+		gEngine.Con_NPrintf(4, "Dirty light cells: %d, size = %dKiB, ranges = %d\n", dirty, (int)(dirty * sizeof(struct LightCluster) / 1024), g_lights.stats.ranges_uploaded);
 	}
 
 	gEngine.Con_NPrintf(5, "Perf scopes:");

--- a/ref_vk/vk_light.c
+++ b/ref_vk/vk_light.c
@@ -536,6 +536,7 @@ void RT_LightsNewMapBegin( const struct model_s *map ) {
 			vk_lights_cell_t *const cell = g_lights.cells + i;
 			cell->num_point_lights = cell->num_static.point_lights = 0;
 			cell->num_polygons = cell->num_static.polygons = 0;
+			cell->dirty = true;
 		}
 	}
 }
@@ -545,10 +546,16 @@ void RT_LightsFrameBegin( void ) {
 	g_lights_.num_point_lights = g_lights_.num_static.point_lights;
 	g_lights_.num_polygon_vertices = g_lights_.num_static.polygon_vertices;
 
+	g_lights.stats.dirty_cells = 0;
+
 	for (int i = 0; i < g_lights.map.grid_cells; ++i) {
 		vk_lights_cell_t *const cell = g_lights.cells + i;
 		cell->num_polygons = cell->num_static.polygons;
 		cell->num_point_lights = cell->num_static.point_lights;
+
+		if (cell->dirty)
+			++g_lights.stats.dirty_cells;
+		cell->dirty = false;
 	}
 }
 
@@ -564,6 +571,7 @@ static qboolean addSurfaceLightToCell( int cell_index, int polygon_light_index )
 	}
 
 	cluster->polygons[cluster->num_polygons++] = polygon_light_index;
+	cluster->dirty = true;
 	return true;
 }
 
@@ -578,6 +586,7 @@ static qboolean addLightToCell( int cell_index, int light_index ) {
 	}
 
 	cluster->point_lights[cluster->num_point_lights++] = light_index;
+	cluster->dirty = true;
 	return true;
 }
 

--- a/ref_vk/vk_light.h
+++ b/ref_vk/vk_light.h
@@ -16,6 +16,8 @@ typedef struct {
 		uint8_t point_lights;
 		uint8_t polygons;
 	} num_static;
+
+	qboolean dirty;
 } vk_lights_cell_t;
 
 typedef struct {
@@ -57,6 +59,10 @@ typedef struct {
 	} map;
 
 	vk_lights_cell_t cells[MAX_LIGHT_CLUSTERS];
+
+	struct {
+		int dirty_cells;
+	} stats;
 } vk_lights_t;
 
 extern vk_lights_t g_lights;

--- a/ref_vk/vk_light.h
+++ b/ref_vk/vk_light.h
@@ -17,7 +17,7 @@ typedef struct {
 		uint8_t polygons;
 	} num_static;
 
-	qboolean dirty;
+	uint32_t frame_sequence;
 } vk_lights_cell_t;
 
 typedef struct {
@@ -62,6 +62,7 @@ typedef struct {
 
 	struct {
 		int dirty_cells;
+		int ranges_uploaded;
 	} stats;
 } vk_lights_t;
 
@@ -83,7 +84,7 @@ typedef struct {
 		uint32_t offset, size;
 	} metadata, grid;
 } vk_lights_bindings_t;
-vk_lights_bindings_t VK_LightsUpload( VkCommandBuffer );
+vk_lights_bindings_t VK_LightsUpload( void );
 
 qboolean RT_GetEmissiveForTexture( vec3_t out, int texture_id );
 

--- a/ref_vk/vk_rtx.c
+++ b/ref_vk/vk_rtx.c
@@ -47,7 +47,7 @@
 		X(Buffer, indices) \
 		X(Buffer, vertices) \
 		X(Buffer, lights) \
-		X(Buffer, light_clusters) \
+		X(Buffer, light_grid) \
 		X(Texture, textures) \
 		X(Texture, skybox)
 
@@ -219,7 +219,7 @@ static void performTracing(VkCommandBuffer cmdbuf, const perform_tracing_args_t*
 
 	// TODO move this to lights
 	RES_SET_BUFFER(lights, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, args->light_bindings->buffer, args->light_bindings->metadata.offset, args->light_bindings->metadata.size);
-	RES_SET_BUFFER(light_clusters, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, args->light_bindings->buffer, args->light_bindings->grid.offset, args->light_bindings->grid.size);
+	RES_SET_BUFFER(light_grid, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, args->light_bindings->buffer, args->light_bindings->grid.offset, args->light_bindings->grid.size);
 #undef RES_SET_SBUFFER_FULL
 #undef RES_SET_BUFFER
 
@@ -547,7 +547,7 @@ void VK_RayFrameEnd(const vk_ray_frame_render_args_t* args)
 	// FIXME pass these matrices explicitly to let RTX module handle ubo itself
 
 	RT_LightsFrameEnd();
-	const vk_lights_bindings_t light_bindings = VK_LightsUpload(cmdbuf);
+	const vk_lights_bindings_t light_bindings = VK_LightsUpload();
 
 	g_rtx.frame_number++;
 


### PR DESCRIPTION
Ends up uploading only a few megs per frame, spread across a hundred or so ranges on average.
Still not great, now validation is too slow. But otherwise it's back to ~60fps.

I think it's end of the line for this approach. Even betterer light clusters would need a complete overhaul, e.g. being moved completely to GPU compute.

Fixes #385 