### PR TITLE
vk: change how device extensions are checked

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -13,10 +13,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             targetos: linux
             targetarch: amd64
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             targetos: linux
             targetarch: i386
 #          - os: ubuntu-aarch64-20.04
@@ -45,7 +45,7 @@ jobs:
             targetarch: i386
     env:
       SDL_VERSION: 2.26.2
-      VULKAN_SDK_VERSION: 1.2.176.1
+      VULKAN_SDK_VERSION: 1.3.239
       GH_CPU_ARCH: ${{ matrix.targetarch }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ANDROID_SDK_TOOLS_VER: 4333796

--- a/ref/vk/vk_core.c
+++ b/ref/vk/vk_core.c
@@ -641,7 +641,6 @@ static qboolean initSurface( void )
 	gEngine.Con_Reportf("Supported surface formats: %u\n", vk_core.surface.num_surface_formats);
 	for (uint32_t i = 0; i < vk_core.surface.num_surface_formats; ++i)
 	{
-		// TODO symbolicate
 		gEngine.Con_Reportf("\t%u: %s(%u) %s(%u)\n", i,
 			R_VkFormatName(vk_core.surface.surface_formats[i].format), vk_core.surface.surface_formats[i].format,
 			R_VkColorSpaceName(vk_core.surface.surface_formats[i].colorSpace), vk_core.surface.surface_formats[i].colorSpace);

--- a/ref/vk/vk_nv_aftermath.c
+++ b/ref/vk/vk_nv_aftermath.c
@@ -1,4 +1,3 @@
-#ifdef USE_AFTERMATH
 #include "vk_nv_aftermath.h"
 
 #include "vk_common.h"
@@ -6,12 +5,27 @@
 
 #include "xash3d_types.h"
 
+#ifdef USE_AFTERMATH
 #include "GFSDK_Aftermath.h"
 #include "GFSDK_Aftermath_GpuCrashDump.h"
 #include "GFSDK_Aftermath_GpuCrashDumpDecoding.h"
+#endif // ifdef USE_AFTERMATH
 
 #include <stdio.h>
 
+#define MAX_NV_CHECKPOINTS 2048
+
+typedef struct {
+	unsigned sequence;
+	char message[256];
+} vk_nv_checkpoint_entry_t;
+
+static struct {
+	unsigned sequence;
+	vk_nv_checkpoint_entry_t entries[MAX_NV_CHECKPOINTS];
+} g_nv_checkpoint = {0};
+
+#ifdef USE_AFTERMATH
 static const char *aftermathErrorName(GFSDK_Aftermath_Result result) {
 	switch (result) {
 #define CASE(c) case c: return #c;
@@ -90,17 +104,6 @@ static void callbackGpuCrashDumpDescription(PFN_GFSDK_Aftermath_AddGpuCrashDumpD
 	addValue(GFSDK_Aftermath_GpuCrashDumpDescriptionKey_ApplicationVersion, "v0.0.1");
 }
 
-#define MAX_NV_CHECKPOINTS 2048
-
-typedef struct {
-	unsigned sequence;
-	char message[256];
-} vk_nv_checkpoint_entry_t;
-
-static struct {
-	unsigned sequence;
-	vk_nv_checkpoint_entry_t entries[MAX_NV_CHECKPOINTS];
-} g_nv_checkpoint = {0};
 
 static const char obsolete[] = "[OBSOLETE]";
 
@@ -136,6 +139,7 @@ void VK_AftermathShutdown() {
 		GFSDK_Aftermath_DisableGpuCrashDumps();
 	}
 }
+#endif //ifdef USE_AFTERMATH
 
 void R_Vk_NV_CheckpointF(VkCommandBuffer cmdbuf, const char *fmt, ...) {
 	ASSERT(vkCmdSetCheckpointNV);
@@ -180,4 +184,3 @@ void R_Vk_NV_Checkpoint_Dump(void) {
 	}
 }
 
-#endif //ifdef USE_AFTERMATH

--- a/ref/vk/vk_nv_aftermath.c
+++ b/ref/vk/vk_nv_aftermath.c
@@ -138,8 +138,9 @@ void VK_AftermathShutdown() {
 }
 
 void R_Vk_NV_CheckpointF(VkCommandBuffer cmdbuf, const char *fmt, ...) {
-	va_list argptr;
+	ASSERT(vkCmdSetCheckpointNV);
 
+	va_list argptr;
 	++g_nv_checkpoint.sequence;
 
 	vk_nv_checkpoint_entry_t *entry = g_nv_checkpoint.entries + (g_nv_checkpoint.sequence % MAX_NV_CHECKPOINTS);
@@ -154,6 +155,8 @@ void R_Vk_NV_CheckpointF(VkCommandBuffer cmdbuf, const char *fmt, ...) {
 }
 
 void R_Vk_NV_Checkpoint_Dump(void) {
+	ASSERT(vkGetQueueCheckpointDataNV);
+
 	uint32_t checkpoints_count = 0;
 	vkGetQueueCheckpointDataNV(vk_core.queue, &checkpoints_count, NULL);
 

--- a/ref/vk/vk_nv_aftermath.h
+++ b/ref/vk/vk_nv_aftermath.h
@@ -1,7 +1,28 @@
 #pragma once
-#ifdef USE_AFTERMATH
+
 #include "xash3d_types.h"
 
+#define VK_NO_PROTOTYPES
+#include <vulkan/vulkan.h>
+
+#ifdef USE_AFTERMATH
 qboolean VK_AftermathInit();
 void VK_AftermathShutdown();
 #endif
+
+void R_Vk_NV_CheckpointF(VkCommandBuffer cmdbuf, const char *fmt, ...);
+void R_Vk_NV_Checkpoint_Dump(void);
+
+#define DEBUG_NV_CHECKPOINTF(cmdbuf, fmt, ...) \
+	do { \
+		if (vk_core.nv_checkpoint) { \
+			R_Vk_NV_CheckpointF(cmdbuf, fmt, ##__VA_ARGS__); \
+		} \
+	} while(0)
+
+#define DEBUG_NV_CHECKPOINT_DUMP() \
+	do { \
+		if (vk_core.nv_checkpoint) { \
+			R_Vk_NV_Checkpoint_Dump(); \
+		} \
+	} while(0)

--- a/scripts/gha/deps_linux.sh
+++ b/scripts/gha/deps_linux.sh
@@ -28,9 +28,9 @@ wget http://libsdl.org/release/SDL2-$SDL_VERSION.zip -O SDL2.zip
 unzip -q SDL2.zip
 mv SDL2-$SDL_VERSION SDL2_src
 
-# ref_vk required Vulkan SDK
+# ref_vk requires Vulkan SDK
 wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
-sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.2.176-bionic.list https://packages.lunarg.com/vulkan/1.2.176/lunarg-vulkan-1.2.176-bionic.list
+sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-${VULKAN_SDK_VERSION}-focal.list https://packages.lunarg.com/vulkan/${VULKAN_SDK_VERSION}/lunarg-vulkan-${VULKAN_SDK_VERSION}-focal.list
 sudo apt update
 [ "$ARCH" = "i386" ] && SUFFIX=":i386" || SUFFIX=""
 sudo apt install -y vulkan-sdk"$SUFFIX"

--- a/scripts/gha/deps_win32.sh
+++ b/scripts/gha/deps_win32.sh
@@ -4,6 +4,6 @@ curl http://libsdl.org/release/SDL2-devel-$SDL_VERSION-VC.zip -o SDL2.zip
 unzip -q SDL2.zip
 mv SDL2-$SDL_VERSION SDL2_VC
 
-curl -L --show-error --output vulkan_sdk.exe https://vulkan.lunarg.com/sdk/download/$VULKAN_SDK_VERSION/windows/vulkan_sdk.exe
+curl -L --show-error --output vulkan_sdk.exe https://vulkan.lunarg.com/sdk/download/${VULKAN_SDK_VERSION}.0/windows/vulkan_sdk.exe
 7z x -ovulkan_sdk vulkan_sdk.exe
 rm -f vulkan_sdk.exe


### PR DESCRIPTION
make nv_checkpoint not depend on rt
split it logically from aftermath
don't crash when this extension is not available