### PR TITLE
rt: only overshoot additive for glow mode

### DIFF
--- a/ref/vk/shaders/light_common.glsl
+++ b/ref/vk/shaders/light_common.glsl
@@ -98,8 +98,8 @@ bool shadowed(vec3 pos, vec3 dir, float dist, bool check_sky) {
 
 			const int instance_kusochki_offset = rayQueryGetIntersectionInstanceCustomIndexEXT(rq, true);
 			const int kusok_index = instance_kusochki_offset + rayQueryGetIntersectionGeometryIndexEXT(rq, true);
-			const uint tex_base_color = getKusok(kusok_index).tex_base_color;
-			if ((tex_base_color & KUSOK_MATERIAL_FLAG_SKYBOX) == 0)
+			const uint flags = getKusok(kusok_index).flags;
+			if ((flags & KUSOK_MATERIAL_FLAG_SKYBOX) == 0)
 				return true;
 		}
 	}

--- a/ref/vk/shaders/ray_interop.h
+++ b/ref/vk/shaders/ray_interop.h
@@ -63,7 +63,8 @@ LIST_SPECIALIZATION_CONSTANTS(DECLARE_SPECIALIZATION_CONSTANT)
 #define SHADER_OFFSET_HIT_REGULAR_BASE 0
 #define SHADER_OFFSET_HIT_SHADOW_BASE 3
 
-#define KUSOK_MATERIAL_FLAG_SKYBOX 0x80000000
+#define KUSOK_MATERIAL_FLAG_SKYBOX (1<<0)
+#define KUSOK_MATERIAL_FLAG_FIXME_GLOW (1<<1)
 
 struct Kusok {
 	uint index_offset;
@@ -85,7 +86,9 @@ struct Kusok {
 
 	float roughness;
 	float metalness;
-	PAD(2)
+	uint flags;
+
+	PAD(1)
 
 	mat4 prev_transform;
 };

--- a/ref/vk/shaders/ray_primary_hit.glsl
+++ b/ref/vk/shaders/ray_primary_hit.glsl
@@ -28,13 +28,12 @@ void primaryRayHit(rayQueryEXT rq, inout RayPayloadPrimary payload) {
 	payload.prev_pos_t = vec4(geom.prev_pos, 0.);
 
 	const Kusok kusok = getKusok(geom.kusok_index);
-	const uint tex_base_color = kusok.tex_base_color;
 
-	if ((tex_base_color & KUSOK_MATERIAL_FLAG_SKYBOX) != 0) {
+	if ((kusok.flags & KUSOK_MATERIAL_FLAG_SKYBOX) != 0) {
 		payload.emissive.rgb = SRGBtoLINEAR(texture(skybox, rayDirection).rgb);
 		return;
 	} else {
-		payload.base_color_a = sampleTexture(tex_base_color, geom.uv, geom.uv_lods);
+		payload.base_color_a = sampleTexture(kusok.tex_base_color, geom.uv, geom.uv_lods);
 		payload.material_rmxx.r = (kusok.tex_roughness > 0) ? sampleTexture(kusok.tex_roughness, geom.uv, geom.uv_lods).r : kusok.roughness;
 		payload.material_rmxx.g = (kusok.tex_metalness > 0) ? sampleTexture(kusok.tex_metalness, geom.uv, geom.uv_lods).r : kusok.metalness;
 

--- a/ref/vk/shaders/trace_additive.glsl
+++ b/ref/vk/shaders/trace_additive.glsl
@@ -20,7 +20,11 @@ vec3 traceAdditive(vec3 pos, vec3 dir, float L) {
 
 		const float hit_t = rayQueryGetIntersectionTEXT(rq, false);
 		const float overshoot = hit_t - L;
-		ret += color * smoothstep(additive_soft_overshoot, 0., overshoot);
+
+		if (overshoot < 0.)
+			ret += color;
+		else if ((kusok.flags & KUSOK_MATERIAL_FLAG_FIXME_GLOW) != 0)
+			ret += color * smoothstep(additive_soft_overshoot, 0., overshoot);
 	}
 	return ret;
 }

--- a/ref/vk/vk_render.h
+++ b/ref/vk/vk_render.h
@@ -30,6 +30,7 @@ typedef enum {
 	kXVkMaterialWater,
 	kXVkMaterialSky,
 	kXVkMaterialEmissive,
+	kXVkMaterialEmissiveGlow,
 	kXVkMaterialConveyor,
 	kXVkMaterialChrome,
 } XVkMaterialType;

--- a/ref/vk/vk_sprite.c
+++ b/ref/vk/vk_sprite.c
@@ -718,7 +718,7 @@ static void R_DrawSpriteQuad( const char *debug_name, mspriteframe_t *frame, vec
 	{
 		const vk_render_geometry_t geometry = {
 			.texture = texture,
-			.material = kXVkMaterialEmissive,
+			.material = render_mode == kRenderGlow ? kXVkMaterialEmissiveGlow : kXVkMaterialEmissive,
 
 			.max_vertex = 4,
 			.vertex_offset = buffer.vertices.unit_offset,


### PR DESCRIPTION
Add another flag to kusochki for glow geometry.
Move flags to a new kusok.flags field.

Fixes #231 (or at least makes it not stand out too much)