### PR TITLE
vk: respect TF_NEAREST/CLAMP/BORDER flags

### DIFF
--- a/ref/vk/vk_core.c
+++ b/ref/vk/vk_core.c
@@ -649,6 +649,35 @@ static qboolean initSurface( void )
 	return true;
 }
 
+// TODO modules
+/*
+typedef struct r_vk_module_s {
+	qboolean (*init)(void);
+	void (*destroy)(void);
+
+	// TODO next: dependecies, refcounts, ...
+} r_vk_module_t;
+
+#define LIST_MODULES(X) ...
+
+=>
+extern const r_vk_module_t vk_instance_module;
+...
+extern const r_vk_module_t vk_rtx_module;
+...
+
+=>
+static const r_vk_module_t *const modules[] = {
+	&vk_instance_module,
+	&vk_device_module,
+	&vk_aftermath_module,
+	&vk_texture_module,
+	...
+	&vk_rtx_module,
+	...
+};
+*/
+
 qboolean R_VkInit( void )
 {
 	// FIXME !!!! handle initialization errors properly: destroy what has already been created
@@ -716,26 +745,6 @@ qboolean R_VkInit( void )
 	if (!R_VkStagingInit())
 		return false;
 
-	// TODO move this to vk_texture module
-	{
-		VkSamplerCreateInfo sci = {
-			.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO,
-			.magFilter = VK_FILTER_LINEAR,
-			.minFilter = VK_FILTER_LINEAR,
-			.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT,// TODO CLAMP_TO_EDGE, for menus
-			.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT,//CLAMP_TO_EDGE,
-			.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT,
-			.anisotropyEnable = vk_core.physical_device.anisotropy_enabled,
-			.maxAnisotropy = vk_core.physical_device.properties.limits.maxSamplerAnisotropy,
-			.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK,
-			.unnormalizedCoordinates = VK_FALSE,
-			.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR,
-			.minLod = 0.f,
-			.maxLod = 16.,
-		};
-		XVK_CHECK(vkCreateSampler(vk_core.device, &sci, NULL, &vk_core.default_sampler));
-	}
-
 	if (!VK_PipelineInit())
 		return false;
 
@@ -802,7 +811,6 @@ void R_VkShutdown( void ) {
 
 	VK_DescriptorShutdown();
 
-	vkDestroySampler(vk_core.device, vk_core.default_sampler, NULL);
 	R_VkStagingShutdown();
 
 	VK_DevMemDestroy();

--- a/ref/vk/vk_core.h
+++ b/ref/vk/vk_core.h
@@ -54,8 +54,6 @@ typedef struct vulkan_core_s {
 	VkDevice device;
 	VkQueue queue;
 
-	VkSampler default_sampler;
-
 	unsigned int num_devices;
 	ref_device_t *devices;
 } vulkan_core_t;

--- a/ref/vk/vk_descriptor.c
+++ b/ref/vk/vk_descriptor.c
@@ -38,20 +38,20 @@ qboolean VK_DescriptorInit( void )
 	{
 		const int num_sets = MAX_TEXTURES;
 		// ... TODO find better place for this; this should be per-pipeline/shader
-		VkDescriptorSetLayoutBinding bindings[] = { {
+		const VkDescriptorSetLayoutBinding bindings[] = { {
 			.binding = 0,
 			.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
 			.descriptorCount = 1,
 			.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT,
-			.pImmutableSamplers = &vk_core.default_sampler,
+			.pImmutableSamplers = NULL,
 		}};
-		VkDescriptorSetLayoutCreateInfo dslci = {
+		const VkDescriptorSetLayoutCreateInfo dslci = {
 			.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
 			.bindingCount = ARRAYSIZE(bindings),
 			.pBindings = bindings,
 		};
 		VkDescriptorSetLayout* tmp_layouts = Mem_Malloc(vk_core.pool, sizeof(VkDescriptorSetLayout) * num_sets);
-		VkDescriptorSetAllocateInfo dsai = {
+		const VkDescriptorSetAllocateInfo dsai = {
 			.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
 			.descriptorPool = vk_desc.pool,
 			.descriptorSetCount = num_sets,

--- a/ref/vk/vk_rtx.c
+++ b/ref/vk/vk_rtx.c
@@ -117,9 +117,10 @@ void VK_RayNewMap( void ) {
 
 	g_rtx.res[ExternalResource_skybox].resource = (vk_resource_t){
 		.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+		// FIXME we should pick tglob.dii_all_textures here directly
 		.value = (vk_descriptor_value_t){
 			.image = {
-				.sampler = vk_core.default_sampler,
+				.sampler = tglob.default_sampler_fixme,
 				.imageView = tglob.skybox_cube.vk.image.view ? tglob.skybox_cube.vk.image.view : tglob.cubemap_placeholder.vk.image.view,
 				.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
 			},

--- a/ref/vk/vk_textures.h
+++ b/ref/vk/vk_textures.h
@@ -26,6 +26,8 @@ typedef struct vk_texture_s
 
 #define MAX_LIGHTMAPS	256
 
+#define MAX_SAMPLERS 8 // TF_NEAREST x 2 * TF_BORDER x 2 * TF_CLAMP x 2
+
 typedef struct vk_textures_global_s
 {
 	int		defaultTexture;   	// use for bad textures
@@ -48,6 +50,14 @@ typedef struct vk_textures_global_s
 	vk_texture_t cubemap_placeholder;
 
 	VkDescriptorImageInfo dii_all_textures[MAX_TEXTURES];
+
+	// FIXME this should not exist, all textures should have their own samplers based on flags
+	VkSampler default_sampler_fixme;
+
+	struct {
+		texFlags_t flags;
+		VkSampler sampler;
+	} samplers[MAX_SAMPLERS];
 } vk_textures_global_t;
 
 // TODO rename this consistently


### PR DESCRIPTION
Use these flags to pick the right sampler. Fixes issues with blurry and leaking fonts, main menu tiles lines, etc

fixes #439, fixes #79