### PR TITLE
vk: start refactoring profiler

### DIFF
--- a/ref/vk/NOTES.md
+++ b/ref/vk/NOTES.md
@@ -1,0 +1,29 @@
+# Frame structure wrt calls from the engine
+- (eng) SCR_UpdateScreen()
+	- (eng) V_PreRender()
+		- **(ref) R_BeginFrame()**
+	- (eng) V_RenderView()
+		- **(ref) GL_BackendStartFrame()** -- ref_gl only sets speeds string to empty here
+			- (eng) loop over ref_params_t views
+				- **(ref) GL_RenderFrame()**
+			- (eng) ??? SV_DrawDebugTriangles()
+		- **(ref) GL_BackendEndFrame()** -- ref_gl only produces speeds string here
+	- (eng) V_PostRender()
+		- **(ref) R_AllowFog(), R_Set2DMode(true)**
+		- **(ref) R_DrawTileClear()** x N
+		- (vgui) Paint() -> ???
+		- (eng) SCR_RSpeeds()
+			- **(ref) R_SpeedsMessage()**
+			- (eng) CL_DrawString() ...
+			  - **(ref) GL_SetRenderMode()**
+				- **(ref) RefGetParm()** for texture resolution
+				- **(ref) Color4ub()**
+				- **(ref) R_DrawStretchPic()**
+		- (eng) SRC_DrawNetGraph()
+			- **(ref) many TriApi calls** -- 2D usage of triapi. we were not ready for this (maybe track R_Set2DMode()?)
+		- **(ref) R_ShowTextures()** kekw
+		- **(ref) VID_ScreenShot()**
+		- **(ref) R_AllowFog(true)**
+		- **(ref) R_EndFrame()**
+
+

--- a/ref/vk/profiler.h
+++ b/ref/vk/profiler.h
@@ -14,6 +14,13 @@
 #define APROF_SCOPE_BEGIN(scope) \
 	aprof_scope_event(_aprof_scope_id_##scope, 1)
 
+#define APROF_SCOPE_DECLARE_BEGIN(scope, scope_name) \
+	static aprof_scope_id_t _aprof_scope_id_##scope = -1; \
+	if (_aprof_scope_id_##scope == -1) { \
+		_aprof_scope_id_##scope = aprof_scope_init(scope_name); \
+	} \
+	aprof_scope_event(_aprof_scope_id_##scope, 1)
+
 #define APROF_TOKENPASTE(x, y) x ## y
 #define APROF_TOKENPASTE2(x, y) APROF_TOKENPASTE(x, y)
 

--- a/ref/vk/profiler.h
+++ b/ref/vk/profiler.h
@@ -40,10 +40,10 @@ void aprof_scope_event(aprof_scope_id_t, int begin);
 uint32_t aprof_scope_frame( void );
 uint64_t aprof_time_now_ns( void );
 
-#ifdef WIN32
-uint64_t aprof_time_now_native_divider( void );
+#if defined(_WIN32)
+uint64_t aprof_time_platform_to_ns( uint64_t );
 #else
-#define aprof_time_now_native_divider() 1
+#define aprof_time_platform_to_ns(time) (time)
 #endif
 
 typedef struct {
@@ -122,8 +122,9 @@ uint64_t aprof_time_now_ns( void ) {
 	QueryPerformanceCounter(&pc);
 	return pc.QuadPart * 1000000000ull / _aprof_frequency.QuadPart;
 }
-uint64_t aprof_time_now_native_divider( void ) {
-	return _aprof_frequency.QuadPart;
+
+uint64_t aprof_time_platform_to_ns( uint64_t platform_time ) {
+	return platform_time * 1000000000ull / _aprof_frequency.QuadPart;
 }
 #else
 #error aprof is not implemented for this os

--- a/ref/vk/r_slows.c
+++ b/ref/vk/r_slows.c
@@ -269,7 +269,7 @@ static void getCurrentFontMetrics(void) {
 }
 
 void R_ShowExtendedProfilingData(uint32_t prev_frame_index, uint64_t gpu_frame_begin_ns, uint64_t gpu_frame_end_ns) {
-	APROF_SCOPE_DECLARE_BEGIN(__FUNCTION__, __FUNCTION__);
+	APROF_SCOPE_DECLARE_BEGIN(function, __FUNCTION__);
 
 	g_slows.frame.message[0] = '\0';
 
@@ -312,7 +312,7 @@ void R_ShowExtendedProfilingData(uint32_t prev_frame_index, uint64_t gpu_frame_b
 		speedsPrintf("Dirty light cells: %d\n\tsize = %dKiB, ranges = %d\n", dirty, (int)(dirty * sizeof(struct LightCluster) / 1024), g_lights.stats.ranges_uploaded);
 	}
 
-	APROF_SCOPE_END(__FUNCTION__);
+	APROF_SCOPE_END(function);
 }
 
 static void togglePause( void ) {

--- a/ref/vk/r_slows.c
+++ b/ref/vk/r_slows.c
@@ -1,0 +1,57 @@
+#include "r_slows.h"
+#include "vk_light.h" // For stats
+#include "shaders/ray_interop.h" // stats: struct LightCluster
+#include "vk_overlay.h"
+#include "vk_framectl.h"
+
+#include "profiler.h"
+
+#define MAX_FRAMES_HISTORY 256
+
+static struct {
+	float frame_times[MAX_FRAMES_HISTORY];
+	uint32_t frame_num;
+} g_slows;
+
+
+static float linearstep(float min, float max, float v) {
+	if (v <= min) return 0;
+	if (v >= max) return 1;
+	return (v - min) / (max - min);
+}
+
+// FIXME move this to r_speeds or something like that
+void R_ShowExtendedProfilingData(uint32_t prev_frame_index) {
+	{
+		const int dirty = g_lights.stats.dirty_cells;
+		gEngine.Con_NPrintf(4, "Dirty light cells: %d, size = %dKiB, ranges = %d\n", dirty, (int)(dirty * sizeof(struct LightCluster) / 1024), g_lights.stats.ranges_uploaded);
+	}
+
+	const uint32_t events = g_aprof.events_last_frame - prev_frame_index;
+	const unsigned long long delta_ns = APROF_EVENT_TIMESTAMP(g_aprof.events[g_aprof.events_last_frame]) - APROF_EVENT_TIMESTAMP(g_aprof.events[prev_frame_index]);
+	const float frame_time = delta_ns / 1e6;
+
+	gEngine.Con_NPrintf(5, "aprof events this frame: %u, wraps: %d, frame time: %.03fms (%lluns)\n", events, g_aprof.current_frame_wraparounds, frame_time, delta_ns);
+
+	g_slows.frame_times[g_slows.frame_num] = frame_time;
+	g_slows.frame_num = (g_slows.frame_num + 1) % MAX_FRAMES_HISTORY;
+
+	const float width = (float)vk_frame.width / MAX_FRAMES_HISTORY;
+	for (int i = 0; i < MAX_FRAMES_HISTORY; ++i) {
+		const float frame_time = g_slows.frame_times[i];
+		CL_FillRGBA(i * width, 100, width, frame_time * 2.f,
+				//255, 255, 255, 255);
+			255*linearstep(16.67, 16.67*2.f, frame_time), 255, 0, 127);
+	}
+
+	/* gEngine.Con_NPrintf(5, "Perf scopes:"); */
+	/* for (int i = 0; i < g_aprof.num_scopes; ++i) { */
+	/* 	const aprof_scope_t *const scope = g_aprof.scopes + i; */
+	/* 	gEngine.Con_NPrintf(6 + i, "%s: c%d t%.03f(%.03f)ms s%.03f(%.03f)ms", scope->name, */
+	/* 		scope->frame.count, */
+	/* 		scope->frame.duration / 1e6, */
+	/* 		(scope->frame.duration / 1e6) / scope->frame.count, */
+	/* 		(scope->frame.duration - scope->frame.duration_children) / 1e6, */
+	/* 		(scope->frame.duration - scope->frame.duration_children) / 1e6 / scope->frame.count); */
+	/* } */
+}

--- a/ref/vk/r_slows.c
+++ b/ref/vk/r_slows.c
@@ -178,7 +178,6 @@ static int drawFrames( uint32_t prev_frame_index, int y, const uint64_t gpu_fram
 	y += g_slows.font_metrics.glyph_height * 6;
 	const int bar_height = g_slows.font_metrics.glyph_height;
 	const rgba_t color = {255, 255, 0, 127};
-	gEngine.Con_Reportf("frame_begin=%.03fs gpu_begin=%.03fs\n", frame_begin_time * 1e-9, gpu_frame_begin_ns * 1e-9);
 	drawTimeBar(frame_begin_time, time_scale_ms, gpu_frame_begin_ns, gpu_frame_end_ns, y, bar_height, "GPU TIME", color);
 	return y;
 }

--- a/ref/vk/r_slows.c
+++ b/ref/vk/r_slows.c
@@ -38,7 +38,14 @@ static uint32_t getHash(const char *s) {
 
 static void drawProfilerScopes(const aprof_event_t *events, uint64_t frame_begin_time, float time_scale_ms, uint32_t begin, uint32_t end, int y) {
 #define MAX_STACK_DEPTH 16
-	const int height = 20;
+
+	// hidpi scaling
+	float scale = gEngine.pfnGetCvarFloat("con_fontscale");
+	if (scale <= 0.f)
+		scale = 1.f;
+
+	// TODO "20" is fine for the "default" font. Unfortunately we don't have any access to font metrics from here, ref_api_t doesn't give us anything about fonts. ;_;
+	const int height = 20 * scale;
 
 	struct {
 		int scope_id;

--- a/ref/vk/r_slows.c
+++ b/ref/vk/r_slows.c
@@ -19,6 +19,10 @@ static struct {
 	aprof_event_t *paused_events;
 	int paused_events_count;
 	int pause_requested;
+
+	struct {
+		int glyph_width, glyph_height;
+	} font_metrics;
 } g_slows;
 
 static float linearstep(float min, float max, float v) {
@@ -36,7 +40,7 @@ static uint32_t getHash(const char *s) {
 	return CRC32_Final(crc);
 }
 
-static void drawTimeBar(uint64_t begin_time_ns, float time_scale_ms, int64_t begin_ns, int64_t end_ns, int y, int height, int glyph_width, const char *label, const rgba_t color) {
+static void drawTimeBar(uint64_t begin_time_ns, float time_scale_ms, int64_t begin_ns, int64_t end_ns, int y, int height, const char *label, const rgba_t color) {
 	const float delta_ms = (end_ns - begin_ns) * 1e-6;
 	const int width = delta_ms  * time_scale_ms;
 	const int x = (begin_ns - begin_time_ns) * 1e-6 * time_scale_ms;
@@ -47,22 +51,13 @@ static void drawTimeBar(uint64_t begin_time_ns, float time_scale_ms, int64_t beg
 	// Tweak this if scope names escape the block boundaries
 	char tmp[64];
 	tmp[0] = '\0';
+	const int glyph_width = g_slows.font_metrics.glyph_width;
 	Q_snprintf(tmp, Q_min(sizeof(tmp), width / glyph_width), "%s %.3fms", label, delta_ms);
 	gEngine.Con_DrawString(x, y, tmp, text_color);
 }
 
 static void drawProfilerScopes(const aprof_event_t *events, uint64_t begin_time, float time_scale_ms, uint32_t begin, uint32_t end, int y) {
 #define MAX_STACK_DEPTH 16
-
-	// hidpi scaling
-	float scale = gEngine.pfnGetCvarFloat("con_fontscale");
-	if (scale <= 0.f)
-		scale = 1.f;
-
-	// TODO "20" is fine for the "default" font. Unfortunately we don't have any access to font metrics from here, ref_api_t doesn't give us anything about fonts. ;_;
-	const int height = 20 * scale;
-	const int estimated_glyph_width = 8 * scale;
-
 	struct {
 		int scope_id;
 		uint64_t begin_ns;
@@ -97,7 +92,8 @@ static void drawProfilerScopes(const aprof_event_t *events, uint64_t begin_time,
 					const uint32_t hash = getHash(scope_name);
 
 					const rgba_t color = {hash >> 24, (hash>>16)&0xff, hash&0xff, 127};
-					drawTimeBar(begin_time, time_scale_ms, stack[depth].begin_ns, timestamp_ns, y + depth * height, height, estimated_glyph_width, scope_name, color);
+					const int bar_height = g_slows.font_metrics.glyph_height;
+					drawTimeBar(begin_time, time_scale_ms, stack[depth].begin_ns, timestamp_ns, y + depth * bar_height, bar_height, scope_name, color);
 					break;
 				}
 
@@ -110,32 +106,27 @@ static void drawProfilerScopes(const aprof_event_t *events, uint64_t begin_time,
 		gEngine.Con_NPrintf(4, S_ERROR "Profiler stack overflow: reached %d, max available %d\n", max_depth, MAX_STACK_DEPTH);
 }
 
-// FIXME move this to r_speeds or something like that
-void R_ShowExtendedProfilingData(uint32_t prev_frame_index, uint64_t gpu_frame_begin_ns, uint64_t gpu_frame_end_ns) {
-	APROF_SCOPE_DECLARE_BEGIN(__FUNCTION__, __FUNCTION__);
+static void handlePause( uint32_t prev_frame_index ) {
+	if (!g_slows.pause_requested || g_slows.paused_events)
+		return;
 
-	int line = 4;
-	{
-		const int dirty = g_lights.stats.dirty_cells;
-		gEngine.Con_NPrintf(line++, "Dirty light cells: %d, size = %dKiB, ranges = %d\n", dirty, (int)(dirty * sizeof(struct LightCluster) / 1024), g_lights.stats.ranges_uploaded);
+	const uint32_t frame_begin = prev_frame_index;
+	const uint32_t frame_end = g_aprof.events_last_frame + 1;
+
+	g_slows.paused_events_count = frame_end >= frame_begin ? frame_end - frame_begin : (frame_end + APROF_EVENT_BUFFER_SIZE - frame_begin);
+	g_slows.paused_events = Mem_Malloc(vk_core.pool, g_slows.paused_events_count * sizeof(g_slows.paused_events[0]));
+
+	if (frame_end >= frame_begin) {
+		memcpy(g_slows.paused_events, g_aprof.events + frame_begin, g_slows.paused_events_count * sizeof(g_slows.paused_events[0]));
+	} else {
+		const int first_chunk = (APROF_EVENT_BUFFER_SIZE - frame_begin) * sizeof(g_slows.paused_events[0]);
+		memcpy(g_slows.paused_events, g_aprof.events + frame_begin, first_chunk);
+		memcpy(g_slows.paused_events + first_chunk, g_aprof.events, frame_end * sizeof(g_slows.paused_events[0]));
 	}
+}
 
-	const uint32_t events = g_aprof.events_last_frame - prev_frame_index;
-	const uint64_t frame_begin_time = APROF_EVENT_TIMESTAMP(g_aprof.events[prev_frame_index]);
-	const unsigned long long delta_ns = APROF_EVENT_TIMESTAMP(g_aprof.events[g_aprof.events_last_frame]) - frame_begin_time;
-	const float frame_time = delta_ns / 1e6;
-
-	const uint64_t gpu_time_ns = gpu_frame_end_ns - gpu_frame_begin_ns;
-	gEngine.Con_NPrintf(line++, "GPU frame time: %.03fms\n", gpu_time_ns * 1e-6);
-
-	gEngine.Con_NPrintf(line++, "aprof events this frame: %u, wraps: %d, frame time: %.03fms\n", events, g_aprof.current_frame_wraparounds, frame_time);
-
-	g_slows.frame_times[g_slows.frame_num] = frame_time;
-	g_slows.frame_num = (g_slows.frame_num + 1) % MAX_FRAMES_HISTORY;
-
+static int drawFrameTimeGraph( const int frame_bar_y, const float frame_bar_y_scale ) {
 	const float width = (float)vk_frame.width / MAX_FRAMES_HISTORY;
-	const int frame_bar_y = 100; // TODO font_height * scale * (line + 1)
-	const float frame_bar_y_scale = 2.f; // ms to pixels
 
 	// 60fps
 	CL_FillRGBA(0, frame_bar_y + frame_bar_y_scale * TARGET_FRAME_TIME, vk_frame.width, 1, 0, 255, 0, 50);
@@ -153,55 +144,85 @@ void R_ShowExtendedProfilingData(uint32_t prev_frame_index, uint64_t gpu_frame_b
 		CL_FillRGBA(i * width, frame_bar_y, width, frame_time * frame_bar_y_scale, red, green, 0, 127);
 	}
 
-	if (g_slows.pause_requested && !g_slows.paused_events) {
-		const uint32_t frame_begin = prev_frame_index;
-		const uint32_t frame_end = g_aprof.events_last_frame + 1;
+	return frame_bar_y + frame_bar_y_scale * TARGET_FRAME_TIME * 2;
+}
 
-		g_slows.paused_events_count = frame_end >= frame_begin ? frame_end - frame_begin : (frame_end + APROF_EVENT_BUFFER_SIZE - frame_begin);
-		g_slows.paused_events = Mem_Malloc(vk_core.pool, g_slows.paused_events_count * sizeof(g_slows.paused_events[0]));
+static int drawFrames( uint32_t prev_frame_index, int y, const uint64_t gpu_frame_begin_ns, const uint64_t gpu_frame_end_ns ) {
+	// Draw latest 2 frames; find their boundaries
+	uint32_t rewind_frame = prev_frame_index;
+	const int max_frames_to_draw = 2;
+	for (int frame = 1; frame < max_frames_to_draw;) {
+		rewind_frame = (rewind_frame - 1) % APROF_EVENT_BUFFER_SIZE; // NOTE: only correct for power-of-2 buffer sizes
+		const aprof_event_t event = g_aprof.events[rewind_frame];
 
-		if (frame_end >= frame_begin) {
-			memcpy(g_slows.paused_events, g_aprof.events + frame_begin, g_slows.paused_events_count * sizeof(g_slows.paused_events[0]));
-		} else {
-			const int first_chunk = (APROF_EVENT_BUFFER_SIZE - frame_begin) * sizeof(g_slows.paused_events[0]);
-			memcpy(g_slows.paused_events, g_aprof.events + frame_begin, first_chunk);
-			memcpy(g_slows.paused_events + first_chunk, g_aprof.events, frame_end * sizeof(g_slows.paused_events[0]));
+		// Exhausted all events
+		if (event == 0 || rewind_frame == g_aprof.events_write)
+			break;
+
+		// Note the frame
+		if (APROF_EVENT_TYPE(event) == APROF_EVENT_FRAME_BOUNDARY) {
+			++frame;
+			prev_frame_index = rewind_frame;
 		}
 	}
+
+	const aprof_event_t *const events = g_slows.paused_events ? g_slows.paused_events : g_aprof.events;
+	const int event_begin = g_slows.paused_events ? 0 : prev_frame_index;
+	const int event_end = g_slows.paused_events ? g_slows.paused_events_count - 1 : g_aprof.events_last_frame;
+	const uint64_t frame_begin_time = APROF_EVENT_TIMESTAMP(events[event_begin]);
+	const uint64_t frame_end_time = APROF_EVENT_TIMESTAMP(events[event_end]);
+	const uint64_t delta_ns = frame_end_time - frame_begin_time;
+	const float time_scale_ms = (double)vk_frame.width / (delta_ns / 1e6);
+	drawProfilerScopes(events, frame_begin_time, time_scale_ms, event_begin, event_end, y);
+
+	y += g_slows.font_metrics.glyph_height * 6;
+	const int bar_height = g_slows.font_metrics.glyph_height;
+	const rgba_t color = {255, 255, 0, 127};
+	gEngine.Con_Reportf("frame_begin=%.03fs gpu_begin=%.03fs\n", frame_begin_time * 1e-9, gpu_frame_begin_ns * 1e-9);
+	drawTimeBar(frame_begin_time, time_scale_ms, gpu_frame_begin_ns, gpu_frame_end_ns, y, bar_height, "GPU TIME", color);
+	return y;
+}
+
+// FIXME move this to r_speeds or something like that
+void R_ShowExtendedProfilingData(uint32_t prev_frame_index, uint64_t gpu_frame_begin_ns, uint64_t gpu_frame_end_ns) {
+	APROF_SCOPE_DECLARE_BEGIN(__FUNCTION__, __FUNCTION__);
 
 	{
-		const int y = frame_bar_y + frame_bar_y_scale * TARGET_FRAME_TIME * 2 + 10;
+		// hidpi scaling
+		float scale = gEngine.pfnGetCvarFloat("con_fontscale");
+		if (scale <= 0.f)
+			scale = 1.f;
 
-		// Draw latest 2 frames; find their boundaries
-		uint32_t rewind_frame = prev_frame_index;
-		for (int frame = 1; frame < 2;) {
-			rewind_frame = (rewind_frame - 1) % APROF_EVENT_BUFFER_SIZE; // NOTE: only correct for power-of-2 buffer sizes
-			const aprof_event_t event = g_aprof.events[rewind_frame];
-
-			// Exhausted all events
-			if (event == 0 || rewind_frame == g_aprof.events_write)
-				break;
-
-			// Note the frame
-			if (APROF_EVENT_TYPE(event) == APROF_EVENT_FRAME_BOUNDARY) {
-				++frame;
-				prev_frame_index = rewind_frame;
-			}
-		}
-
-		const aprof_event_t *const events = g_slows.paused_events ? g_slows.paused_events : g_aprof.events;
-		const int event_begin = g_slows.paused_events ? 0 : prev_frame_index;
-		const int event_end = g_slows.paused_events ? g_slows.paused_events_count - 1 : g_aprof.events_last_frame;
-		const uint64_t frame_begin_time = APROF_EVENT_TIMESTAMP(events[event_begin]);
-		const uint64_t frame_end_time = APROF_EVENT_TIMESTAMP(events[event_end]);
-		const uint64_t delta_ns = frame_end_time - frame_begin_time;
-		const float time_scale_ms = (double)vk_frame.width / (delta_ns / 1e6);
-		drawProfilerScopes(events, frame_begin_time, time_scale_ms, event_begin, event_end, y);
-
-		const rgba_t color = {255, 255, 0, 127};
-		drawTimeBar(frame_begin_time, time_scale_ms, gpu_frame_begin_ns, gpu_frame_end_ns, 10, 20, 8, "GPU TIME", color);
+		// TODO these numbers are mostly fine for the "default" font. Unfortunately
+		// we don't have any access to real font metrics from here, ref_api_t doesn't give us anything about fonts. ;_;
+		g_slows.font_metrics.glyph_width = 8 * scale;
+		g_slows.font_metrics.glyph_height = 20 * scale;
 	}
 
+	int line = 4;
+	{
+		const int dirty = g_lights.stats.dirty_cells;
+		gEngine.Con_NPrintf(line++, "Dirty light cells: %d, size = %dKiB, ranges = %d\n", dirty, (int)(dirty * sizeof(struct LightCluster) / 1024), g_lights.stats.ranges_uploaded);
+	}
+
+	const uint32_t events = g_aprof.events_last_frame - prev_frame_index;
+	const uint64_t frame_begin_time = APROF_EVENT_TIMESTAMP(g_aprof.events[prev_frame_index]);
+	const unsigned long long delta_ns = APROF_EVENT_TIMESTAMP(g_aprof.events[g_aprof.events_last_frame]) - frame_begin_time;
+	const float frame_time = delta_ns / 1e6;
+
+	const uint64_t gpu_time_ns = gpu_frame_end_ns - gpu_frame_begin_ns;
+	gEngine.Con_NPrintf(line++, "GPU frame time: %.03fms\n", gpu_time_ns * 1e-6);
+	gEngine.Con_NPrintf(line++, "aprof events this frame: %u, wraps: %d, frame time: %.03fms\n", events, g_aprof.current_frame_wraparounds, frame_time);
+
+	g_slows.frame_times[g_slows.frame_num] = frame_time;
+	g_slows.frame_num = (g_slows.frame_num + 1) % MAX_FRAMES_HISTORY;
+
+	handlePause( prev_frame_index );
+
+	int y = 100;
+	const float frame_bar_y_scale = 2.f; // ms to pixels (somehow)
+	y = drawFrameTimeGraph( y, frame_bar_y_scale ) + 20;
+	y = drawFrames( prev_frame_index, y, gpu_frame_begin_ns, gpu_frame_end_ns );
 	APROF_SCOPE_END(__FUNCTION__);
 }
 

--- a/ref/vk/r_slows.c
+++ b/ref/vk/r_slows.c
@@ -6,6 +6,9 @@
 
 #include "profiler.h"
 
+#include "crclib.h" // CRC32 for stable random colors
+#include "xash3d_mathlib.h" // Q_min
+
 #define MAX_FRAMES_HISTORY 256
 #define TARGET_FRAME_TIME (1000.f / 60.f)
 
@@ -14,11 +17,79 @@ static struct {
 	uint32_t frame_num;
 } g_slows;
 
-
 static float linearstep(float min, float max, float v) {
 	if (v <= min) return 0;
 	if (v >= max) return 1;
 	return (v - min) / (max - min);
+}
+
+#define P(fmt, ...) gEngine.Con_Reportf(fmt, ##__VA_ARGS__)
+
+static uint32_t getHash(const char *s) {
+	dword crc;
+	CRC32_Init(&crc);
+	CRC32_ProcessBuffer(&crc, s, Q_strlen(s));
+	return CRC32_Final(crc);
+}
+
+static void drawProfilerScopes(uint64_t frame_begin_time, float time_scale_ms, uint32_t begin, uint32_t end, int y) {
+#define MAX_STACK_DEPTH 16
+	const int height = 20;
+
+	struct {
+		int scope_id;
+		uint64_t begin_ns;
+	} stack[MAX_STACK_DEPTH];
+	int depth = 0;
+	int max_depth = 0;
+
+	for (; begin != end; begin = (begin + 1) % APROF_EVENT_BUFFER_SIZE) {
+		const aprof_event_t event = g_aprof.events[begin];
+		const int event_type = APROF_EVENT_TYPE(event);
+		const uint64_t timestamp_ns = APROF_EVENT_TIMESTAMP(event);
+		const int scope_id = APROF_EVENT_SCOPE_ID(event);
+		switch (event_type) {
+			case APROF_EVENT_SCOPE_BEGIN: {
+					if (depth < MAX_STACK_DEPTH) {
+						stack[depth].begin_ns = timestamp_ns;
+						stack[depth].scope_id = scope_id;
+					}
+					++depth;
+					if (max_depth < depth)
+						max_depth = depth;
+					break;
+				}
+
+			case APROF_EVENT_SCOPE_END: {
+					ASSERT(depth > 0);
+					--depth;
+
+					ASSERT(stack[depth].scope_id == scope_id);
+
+					const int width = (timestamp_ns - stack[depth].begin_ns) * 1e-6 * time_scale_ms;
+					const int x = (stack[depth].begin_ns - frame_begin_time) * 1e-6 * time_scale_ms;
+
+					const int yy = y + depth * height;
+					const char *scope_name = g_aprof.scopes[scope_id].name;
+					const uint32_t hash = getHash(scope_name);
+
+					rgba_t color = {hash >> 24, (hash>>16)&0xff, hash&0xff, 127};
+					rgba_t text_color = {255-color[0], 255-color[1], 255-color[2], 255};
+					CL_FillRGBA(x, yy, width, height, color[0], color[1], color[2], color[3]);
+					char tmp[64];
+					tmp[0] = '\0';
+					Q_strncpy(tmp, scope_name, Q_min(sizeof(tmp), width / 10));
+					gEngine.Con_DrawString(x, yy, tmp, text_color);
+					break;
+				}
+
+			default:
+				break;
+		}
+	}
+
+	if (max_depth > MAX_STACK_DEPTH)
+		gEngine.Con_NPrintf(4, S_ERROR "Profiler stack overflow: reached %d, max available %d\n", max_depth, MAX_STACK_DEPTH);
 }
 
 // FIXME move this to r_speeds or something like that
@@ -29,7 +100,8 @@ void R_ShowExtendedProfilingData(uint32_t prev_frame_index) {
 	}
 
 	const uint32_t events = g_aprof.events_last_frame - prev_frame_index;
-	const unsigned long long delta_ns = APROF_EVENT_TIMESTAMP(g_aprof.events[g_aprof.events_last_frame]) - APROF_EVENT_TIMESTAMP(g_aprof.events[prev_frame_index]);
+	const uint64_t frame_begin_time = APROF_EVENT_TIMESTAMP(g_aprof.events[prev_frame_index]);
+	const unsigned long long delta_ns = APROF_EVENT_TIMESTAMP(g_aprof.events[g_aprof.events_last_frame]) - frame_begin_time;
 	const float frame_time = delta_ns / 1e6;
 
 	gEngine.Con_NPrintf(5, "aprof events this frame: %u, wraps: %d, frame time: %.03fms\n", events, g_aprof.current_frame_wraparounds, frame_time);
@@ -38,6 +110,15 @@ void R_ShowExtendedProfilingData(uint32_t prev_frame_index) {
 	g_slows.frame_num = (g_slows.frame_num + 1) % MAX_FRAMES_HISTORY;
 
 	const float width = (float)vk_frame.width / MAX_FRAMES_HISTORY;
+	const int frame_bar_y = 100;
+	const float frame_bar_y_scale = 2.f; // ms to pixels
+
+	// 60fps
+	CL_FillRGBA(0, frame_bar_y + frame_bar_y_scale * TARGET_FRAME_TIME, vk_frame.width, 1, 0, 255, 0, 50);
+
+	// 30fps
+	CL_FillRGBA(0, frame_bar_y + frame_bar_y_scale * TARGET_FRAME_TIME * 2, vk_frame.width, 1, 255, 0, 0, 50);
+
 	for (int i = 0; i < MAX_FRAMES_HISTORY; ++i) {
 		const float frame_time = g_slows.frame_times[(g_slows.frame_num + i) % MAX_FRAMES_HISTORY];
 
@@ -45,7 +126,13 @@ void R_ShowExtendedProfilingData(uint32_t prev_frame_index) {
 		const float time = linearstep(TARGET_FRAME_TIME, TARGET_FRAME_TIME*2.f, frame_time);
 		const int red = 255 * time;
 		const int green = 255 * (1 - time);
-		CL_FillRGBA(i * width, 100, width, frame_time * 2.f, red, green, 0, 127);
+		CL_FillRGBA(i * width, frame_bar_y, width, frame_time * frame_bar_y_scale, red, green, 0, 127);
+	}
+
+	{
+		const float time_scale_ms = (double)vk_frame.width / (delta_ns / 1e6);
+		const int y = frame_bar_y + frame_bar_y_scale * TARGET_FRAME_TIME * 2;
+		drawProfilerScopes(frame_begin_time, time_scale_ms, prev_frame_index, g_aprof.events_last_frame, y);
 	}
 
 	/* gEngine.Con_NPrintf(5, "Perf scopes:"); */

--- a/ref/vk/r_slows.h
+++ b/ref/vk/r_slows.h
@@ -3,4 +3,4 @@
 
 void R_SlowsInit( void );
 
-void R_ShowExtendedProfilingData(uint32_t prev_frame_event_index, uint64_t gpu_time_ns);
+void R_ShowExtendedProfilingData(uint32_t prev_frame_index, uint64_t gpu_frame_begin_ns, uint64_t gpu_frame_end_ns);

--- a/ref/vk/r_slows.h
+++ b/ref/vk/r_slows.h
@@ -1,6 +1,9 @@
 #pragma once
+#include "xash3d_types.h"
 #include <stdint.h>
 
 void R_SlowsInit( void );
 
 void R_ShowExtendedProfilingData(uint32_t prev_frame_index, uint64_t gpu_frame_begin_ns, uint64_t gpu_frame_end_ns);
+
+qboolean	R_SpeedsMessage( char *out, size_t size );

--- a/ref/vk/r_slows.h
+++ b/ref/vk/r_slows.h
@@ -3,4 +3,4 @@
 
 void R_SlowsInit( void );
 
-void R_ShowExtendedProfilingData(uint32_t prev_frame_event_index);
+void R_ShowExtendedProfilingData(uint32_t prev_frame_event_index, uint64_t gpu_time_ns);

--- a/ref/vk/r_slows.h
+++ b/ref/vk/r_slows.h
@@ -1,4 +1,6 @@
 #pragma once
 #include <stdint.h>
 
+void R_SlowsInit( void );
+
 void R_ShowExtendedProfilingData(uint32_t prev_frame_event_index);

--- a/ref/vk/r_slows.h
+++ b/ref/vk/r_slows.h
@@ -1,0 +1,4 @@
+#pragma once
+#include <stdint.h>
+
+void R_ShowExtendedProfilingData(uint32_t prev_frame_event_index);

--- a/ref/vk/vk_common.h
+++ b/ref/vk/vk_common.h
@@ -1,4 +1,3 @@
-//#include "xash3d_types.h"
 #include "const.h" // required for ref_api.h
 #include "cvardef.h"
 #include "com_model.h"

--- a/ref/vk/vk_core.c
+++ b/ref/vk/vk_core.c
@@ -18,6 +18,7 @@
 #include "vk_nv_aftermath.h"
 #include "vk_devmem.h"
 #include "vk_commandpool.h"
+#include "r_slows.h"
 
 // FIXME move this rt-specific stuff out
 #include "vk_light.h"
@@ -686,6 +687,8 @@ qboolean R_VkInit( void )
 	vk_core.debug = vk_core.validate || !!(gEngine.Sys_CheckParm("-vkdebug") || gEngine.Sys_CheckParm("-gldebug"));
 	vk_core.rtx = false;
 	VK_LoadCvars();
+
+	R_SlowsInit();
 
 	if( !gEngine.R_Init_Video( REF_VULKAN )) // request Vulkan surface
 	{

--- a/ref/vk/vk_core.c
+++ b/ref/vk/vk_core.c
@@ -103,6 +103,10 @@ static const char* device_extensions_nv_checkpoint[] = {
 	VK_NV_DEVICE_DIAGNOSTICS_CONFIG_EXTENSION_NAME,
 };
 
+static const char* device_extensions_extra[] = {
+	VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME,
+};
+
 VkBool32 VKAPI_PTR debugCallback(
     VkDebugUtilsMessageSeverityFlagBitsEXT           messageSeverity,
     VkDebugUtilsMessageTypeFlagsEXT                  messageTypes,
@@ -303,6 +307,7 @@ typedef struct {
 	qboolean anisotropy;
 	qboolean ray_tracing;
 	qboolean nv_checkpoint;
+	qboolean calibrated_timestamps;
 } vk_available_device_t;
 
 static int enumerateDevices( vk_available_device_t **available_devices ) {
@@ -404,6 +409,7 @@ static int enumerateDevices( vk_available_device_t **available_devices ) {
 			devicePrintExtensionsFromList(extensions, num_device_extensions, device_extensions_req, ARRAYSIZE(device_extensions_req));
 			devicePrintExtensionsFromList(extensions, num_device_extensions, device_extensions_rt, ARRAYSIZE(device_extensions_rt));
 			devicePrintExtensionsFromList(extensions, num_device_extensions, device_extensions_nv_checkpoint, ARRAYSIZE(device_extensions_nv_checkpoint));
+			devicePrintExtensionsFromList(extensions, num_device_extensions, device_extensions_extra, ARRAYSIZE(device_extensions_extra));
 
 			vkGetPhysicalDeviceFeatures2(physical_devices[i], &features);
 			this_device->anisotropy = features.features.samplerAnisotropy;
@@ -414,6 +420,8 @@ static int enumerateDevices( vk_available_device_t **available_devices ) {
 
 			this_device->nv_checkpoint = vk_core.debug && deviceSupportsExtensions(extensions, num_device_extensions, device_extensions_nv_checkpoint, ARRAYSIZE(device_extensions_nv_checkpoint));
 			gEngine.Con_Printf("\t\tNV checkpoints supported: %d\n", this_device->nv_checkpoint);
+
+			this_device->calibrated_timestamps = deviceSupportsExtensions(extensions, num_device_extensions, device_extensions_extra, ARRAYSIZE(device_extensions_extra));
 
 			Mem_Free(extensions);
 		}
@@ -556,6 +564,9 @@ static qboolean createDevice( void ) {
 			device_extensions_count = appendDeviceExtensions(device_extensions, device_extensions_count, device_extensions_rt, ARRAYSIZE(device_extensions_rt));
 		if (candidate_device->nv_checkpoint)
 			device_extensions_count = appendDeviceExtensions(device_extensions, device_extensions_count, device_extensions_nv_checkpoint, ARRAYSIZE(device_extensions_nv_checkpoint));
+
+		if (candidate_device->calibrated_timestamps)
+			device_extensions_count = appendDeviceExtensions(device_extensions, device_extensions_count, device_extensions_extra, ARRAYSIZE(device_extensions_extra));
 
 		VkDeviceCreateInfo create_info = {
 			.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,

--- a/ref/vk/vk_core.h
+++ b/ref/vk/vk_core.h
@@ -246,6 +246,11 @@ do { \
 	X(vkGetImageSubresourceLayout) \
 	X(vkCmdSetCheckpointNV) \
 	X(vkGetQueueCheckpointDataNV) \
+	X(vkCreateQueryPool) \
+	X(vkDestroyQueryPool) \
+	X(vkCmdResetQueryPool) \
+	X(vkCmdWriteTimestamp) \
+	X(vkGetQueryPoolResults) \
 
 #define DEVICE_FUNCS_RTX(X) \
 	X(vkGetAccelerationStructureBuildSizesKHR) \

--- a/ref/vk/vk_core.h
+++ b/ref/vk/vk_core.h
@@ -251,6 +251,7 @@ do { \
 	X(vkCmdResetQueryPool) \
 	X(vkCmdWriteTimestamp) \
 	X(vkGetQueryPoolResults) \
+	X(vkGetCalibratedTimestampsEXT) \
 
 #define DEVICE_FUNCS_RTX(X) \
 	X(vkGetAccelerationStructureBuildSizesKHR) \

--- a/ref/vk/vk_cvar.c
+++ b/ref/vk/vk_cvar.c
@@ -6,13 +6,15 @@
 DECLARE_CVAR(NONEXTERN_CVAR)
 #undef NONEXTERN_CVAR
 
-static cvar_t *r_drawentities;
+DEFINE_ENGINE_SHARED_CVAR_LIST()
 
 void VK_LoadCvars( void )
 {
+#define gEngfuncs gEngine // ...
+	RETRIEVE_ENGINE_SHARED_CVAR_LIST()
+
 	r_lighting_modulate = gEngine.Cvar_Get( "r_lighting_modulate", "0.6", FCVAR_ARCHIVE, "lightstyles modulate scale" );
 	cl_lightstyle_lerping = gEngine.pfnGetCvarPointer( "cl_lightstyle_lerping", 0 );
-	r_drawentities = gEngine.pfnGetCvarPointer( "r_drawentities", 0 );
 	r_lightmap = gEngine.Cvar_Get( "r_lightmap", "0", FCVAR_CHEAT, "lightmap debugging tool" );
 	ui_infotool = gEngine.Cvar_Get( "ui_infotool", "0", FCVAR_CHEAT, "DEBUG: print entity info under crosshair" );
 	vk_only = gEngine.Cvar_Get( "vk_only", "0", FCVAR_GLCONFIG, "Full disable Ray Tracing pipeline" );

--- a/ref/vk/vk_cvar.h
+++ b/ref/vk/vk_cvar.h
@@ -2,6 +2,11 @@
 
 #include "cvardef.h"
 
+#include "xash3d_types.h" // required for ref_api.h
+#include "const.h" // required for ref_api.h
+#include "com_model.h" // required for ref_api.h
+#include "ref_api.h"
+
 // from engine/common/cvar.h
 #define FCVAR_READ_ONLY		(1<<17)	// cannot be set by user at all, and can't be requested by CvarGetPointer from game dlls
 
@@ -23,7 +28,8 @@ void VK_LoadCvarsAfterInit( void );
 	X(vk_only) \
 	X(vk_device_target_id) \
 
-
 #define EXTERN_CVAR(cvar) extern cvar_t *cvar;
 DECLARE_CVAR(EXTERN_CVAR)
 #undef EXTERN_CVAR
+
+DECLARE_ENGINE_SHARED_CVAR_LIST()

--- a/ref/vk/vk_framectl.c
+++ b/ref/vk/vk_framectl.c
@@ -214,9 +214,10 @@ void R_BeginFrame( qboolean clearScene ) {
 	APROF_SCOPE_BEGIN(begin_frame);
 
 	{
-		// FIXME correct only for nvidia where timestamps are ns
-		const uint64_t gpu_time_ns_fixme = (qpool->used) ? qpool->results[1] - qpool->results[0] : 0;
-		R_ShowExtendedProfilingData(prev_frame_event_index, gpu_time_ns_fixme);
+		// FIXME collect and show more gpu profiling data
+		const uint64_t gpu_time_begin_ns = (qpool->used) ? qpool->results[0] : 0;
+		const uint64_t gpu_time_end_ns = (qpool->used) ? qpool->results[1] : 0;
+		R_ShowExtendedProfilingData(prev_frame_event_index, gpu_time_begin_ns, gpu_time_end_ns);
 	}
 
 	if (vk_core.rtx && FBitSet( vk_rtx->flags, FCVAR_CHANGED )) {

--- a/ref/vk/vk_framectl.c
+++ b/ref/vk/vk_framectl.c
@@ -49,14 +49,14 @@ static struct {
 } g_frame;
 
 #define PROFILER_SCOPES(X) \
-	X(frame, "Frame"); \
-	X(begin_frame, "R_BeginFrame"); \
-	X(render_frame, "VK_RenderFrame"); \
-	X(end_frame, "R_EndFrame"); \
-	X(frame_gpu_wait, "Wait for GPU"); \
-	X(wait_for_frame_fence, "waitForFrameFence"); \
+	X(frame, "Frame", APROF_SCOPE_FLAG_DECOR); \
+	X(begin_frame, "R_BeginFrame", 0); \
+	X(render_frame, "VK_RenderFrame", 0); \
+	X(end_frame, "R_EndFrame", 0); \
+	X(frame_gpu_wait, "Wait for GPU", APROF_SCOPE_FLAG_WAIT); \
+	X(wait_for_frame_fence, "waitForFrameFence", APROF_SCOPE_FLAG_WAIT); \
 
-#define SCOPE_DECLARE(scope, name) APROF_SCOPE_DECLARE(scope)
+#define SCOPE_DECLARE(scope, name, flags) APROF_SCOPE_DECLARE(scope)
 PROFILER_SCOPES(SCOPE_DECLARE)
 #undef SCOPE_DECLARE
 
@@ -391,7 +391,7 @@ static void toggleRaytracing( void ) {
 
 qboolean VK_FrameCtlInit( void )
 {
-	PROFILER_SCOPES(APROF_SCOPE_INIT);
+	PROFILER_SCOPES(APROF_SCOPE_INIT_EX);
 
 	const VkFormat depth_format = findSupportedImageFormat(depth_formats, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT);
 

--- a/ref/vk/vk_framectl.h
+++ b/ref/vk/vk_framectl.h
@@ -22,6 +22,8 @@ typedef struct vk_framectl_s {
 		// Preserves color buffer contents
 		VkRenderPass after_ray_tracing;
 	} render_pass;
+
+	qboolean rtx_enabled;
 } vk_framectl_t;
 
 extern vk_framectl_t vk_frame;

--- a/ref/vk/vk_querypool.c
+++ b/ref/vk/vk_querypool.c
@@ -56,7 +56,7 @@ static uint64_t getGpuTimestampOffsetNs( const vk_query_pool_t *pool ) {
 		{
 			.sType = VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_EXT,
 			.pNext = NULL,
-#ifdef WIN32
+#if defined(_WIN32)
 			.timeDomain = VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT,
 #else
 			.timeDomain = VK_TIME_DOMAIN_CLOCK_MONOTONIC_EXT,
@@ -68,7 +68,7 @@ static uint64_t getGpuTimestampOffsetNs( const vk_query_pool_t *pool ) {
 	uint64_t max_deviation[2] = {0};
 	vkGetCalibratedTimestampsEXT(vk_core.device, 2, cti, timestamps, max_deviation);
 
-	const uint64_t cpu = (double)timestamps[1] / aprof_time_now_native_divider();
+	const uint64_t cpu = aprof_time_platform_to_ns(timestamps[1]);
 	const uint64_t gpu = (double)timestamps[0] * vk_core.physical_device.properties.limits.timestampPeriod;
 	return cpu - gpu;
 }

--- a/ref/vk/vk_querypool.c
+++ b/ref/vk/vk_querypool.c
@@ -1,4 +1,5 @@
 #include "vk_querypool.h"
+#include "profiler.h" // for aprof_time_now_ns()
 
 qboolean R_VkQueryPoolInit( vk_query_pool_t* pool ) {
 	const VkQueryPoolCreateInfo qpci = {
@@ -33,6 +34,43 @@ void R_VkQueryPoolBegin( vk_query_pool_t *pool, VkCommandBuffer cmdbuf ) {
 
 void R_VkQueryPoolEnd( vk_query_pool_t *pool, VkCommandBuffer cmdbuf ) {
 	R_VkQueryPoolTimestamp(pool, cmdbuf, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
+	pool->end_timestamp_ns = aprof_time_now_ns();
+}
+
+static uint64_t getGpuTimestampOffsetNs( const vk_query_pool_t *pool ) {
+	// FIXME this is an incorrect check, we need to carry per-device extensions availability somehow. vk_core-vs-device refactoring pending
+	if (!vkGetCalibratedTimestampsEXT) {
+		// Estimate based on supposed submission time, assuming that we submit, and it starts computing right after cmdbuffer closure
+		// which may not be true. But it's all we got
+		// TODO alternative approach: estimate based on end timestamp
+		const uint64_t gpu_begin_ns = (double)pool->results[0] * vk_core.physical_device.properties.limits.timestampPeriod;
+		return pool->end_timestamp_ns - gpu_begin_ns;
+	}
+
+	const VkCalibratedTimestampInfoEXT cti[2] = {
+		{
+			.sType = VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_EXT,
+			.pNext = NULL,
+			.timeDomain = VK_TIME_DOMAIN_DEVICE_EXT,
+		},
+		{
+			.sType = VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_EXT,
+			.pNext = NULL,
+#ifdef WIN32
+			.timeDomain = VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT,
+#else
+			.timeDomain = VK_TIME_DOMAIN_CLOCK_MONOTONIC_EXT,
+#endif
+		},
+	};
+
+	uint64_t timestamps[2] = {0};
+	uint64_t max_deviation[2] = {0};
+	vkGetCalibratedTimestampsEXT(vk_core.device, 2, cti, timestamps, max_deviation);
+
+	const uint64_t cpu = (double)timestamps[1] / aprof_time_now_native_divider();
+	const uint64_t gpu = (double)timestamps[0] * vk_core.physical_device.properties.limits.timestampPeriod;
+	return cpu - gpu;
 }
 
 void R_VkQueryPoolGetFrameResults( vk_query_pool_t *pool ) {
@@ -41,7 +79,10 @@ void R_VkQueryPoolGetFrameResults( vk_query_pool_t *pool ) {
 
 	vkGetQueryPoolResults(vk_core.device, pool->pool, 0, pool->used, pool->used * sizeof(uint64_t), pool->results, sizeof(uint64_t), VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
 
+	const uint64_t timestamp_offset_ns = getGpuTimestampOffsetNs( pool ) - g_aprof.time_begin_ns;
+
 	for (int i = 0; i < pool->used; ++i) {
-		pool->results[i] *= vk_core.physical_device.properties.limits.timestampPeriod;
+		const uint64_t gpu_ns = pool->results[i] * (double)vk_core.physical_device.properties.limits.timestampPeriod;
+		pool->results[i] = timestamp_offset_ns + gpu_ns;
 	}
 }

--- a/ref/vk/vk_querypool.c
+++ b/ref/vk/vk_querypool.c
@@ -1,0 +1,43 @@
+#include "vk_querypool.h"
+
+qboolean R_VkQueryPoolInit( vk_query_pool_t* pool ) {
+	const VkQueryPoolCreateInfo qpci = {
+		.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO,
+		.pNext = NULL,
+		.queryType = VK_QUERY_TYPE_TIMESTAMP,
+		.queryCount = MAX_QUERY_COUNT,
+		.flags = 0,
+	};
+
+	XVK_CHECK(vkCreateQueryPool(vk_core.device, &qpci, NULL, &pool->pool));
+	return true;
+}
+
+void R_VkQueryPoolDestroy( vk_query_pool_t *pool ) {
+	vkDestroyQueryPool(vk_core.device, pool->pool, NULL);
+}
+
+int R_VkQueryPoolTimestamp( vk_query_pool_t *pool, VkCommandBuffer cmdbuf, VkPipelineStageFlagBits stage) {
+	if (pool->used >= MAX_QUERY_COUNT)
+		return -1;
+
+	vkCmdWriteTimestamp(cmdbuf, stage, pool->pool, pool->used);
+	return pool->used++;
+}
+
+void R_VkQueryPoolBegin( vk_query_pool_t *pool, VkCommandBuffer cmdbuf ) {
+	pool->used = 0;
+	vkCmdResetQueryPool(cmdbuf, pool->pool, 0, MAX_QUERY_COUNT);
+	R_VkQueryPoolTimestamp(pool, cmdbuf, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+}
+
+void R_VkQueryPoolEnd( vk_query_pool_t *pool, VkCommandBuffer cmdbuf ) {
+	R_VkQueryPoolTimestamp(pool, cmdbuf, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
+}
+
+void R_VkQueryPoolGetFrameResults( vk_query_pool_t *pool ) {
+	if (!pool->used)
+		return;
+
+	vkGetQueryPoolResults(vk_core.device, pool->pool, 0, pool->used, pool->used * sizeof(uint64_t), pool->results, sizeof(uint64_t), VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
+}

--- a/ref/vk/vk_querypool.c
+++ b/ref/vk/vk_querypool.c
@@ -79,7 +79,7 @@ void R_VkQueryPoolGetFrameResults( vk_query_pool_t *pool ) {
 
 	vkGetQueryPoolResults(vk_core.device, pool->pool, 0, pool->used, pool->used * sizeof(uint64_t), pool->results, sizeof(uint64_t), VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
 
-	const uint64_t timestamp_offset_ns = getGpuTimestampOffsetNs( pool ) - g_aprof.time_begin_ns;
+	const uint64_t timestamp_offset_ns = getGpuTimestampOffsetNs( pool );
 
 	for (int i = 0; i < pool->used; ++i) {
 		const uint64_t gpu_ns = pool->results[i] * (double)vk_core.physical_device.properties.limits.timestampPeriod;

--- a/ref/vk/vk_querypool.c
+++ b/ref/vk/vk_querypool.c
@@ -40,4 +40,8 @@ void R_VkQueryPoolGetFrameResults( vk_query_pool_t *pool ) {
 		return;
 
 	vkGetQueryPoolResults(vk_core.device, pool->pool, 0, pool->used, pool->used * sizeof(uint64_t), pool->results, sizeof(uint64_t), VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
+
+	for (int i = 0; i < pool->used; ++i) {
+		pool->results[i] *= vk_core.physical_device.properties.limits.timestampPeriod;
+	}
 }

--- a/ref/vk/vk_querypool.h
+++ b/ref/vk/vk_querypool.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "vk_core.h"
+
+#define MAX_QUERY_COUNT 128
+
+typedef struct {
+	VkQueryPool pool;
+	int used;
+	uint64_t results[MAX_QUERY_COUNT];
+} vk_query_pool_t;
+
+qboolean R_VkQueryPoolInit( vk_query_pool_t *pool );
+void R_VkQueryPoolDestroy( vk_query_pool_t *pool );
+int R_VkQueryPoolTimestamp( vk_query_pool_t *pool, VkCommandBuffer cmdbuf, VkPipelineStageFlagBits stage);
+void R_VkQueryPoolBegin( vk_query_pool_t *pool, VkCommandBuffer cmdbuf );
+void R_VkQueryPoolEnd( vk_query_pool_t *pool, VkCommandBuffer cmdbuf );
+
+void R_VkQueryPoolGetFrameResults( vk_query_pool_t *pool );

--- a/ref/vk/vk_querypool.h
+++ b/ref/vk/vk_querypool.h
@@ -8,6 +8,7 @@ typedef struct {
 	VkQueryPool pool;
 	int used;
 	uint64_t results[MAX_QUERY_COUNT];
+	uint64_t end_timestamp_ns;
 } vk_query_pool_t;
 
 qboolean R_VkQueryPoolInit( vk_query_pool_t *pool );

--- a/ref/vk/vk_rmain.c
+++ b/ref/vk/vk_rmain.c
@@ -13,6 +13,7 @@
 #include "vk_brush.h"
 #include "vk_rpart.h"
 #include "vk_triapi.h"
+#include "r_slows.h"
 
 #include "xash3d_types.h"
 #include "com_strings.h"
@@ -43,13 +44,13 @@ static void GL_ClearExtensions( void )
 {
 	PRINT_NOT_IMPLEMENTED();
 }
-static void GL_BackendStartFrame( void )
+static void GL_BackendStartFrame_UNUSED( void )
 {
-	PRINT_NOT_IMPLEMENTED();
+	/* Unused in Vulkan renderer. GL renderer only uses this to clear the r_speeds_msg string */
 }
-static void GL_BackendEndFrame( void )
+static void GL_BackendEndFrame_UNUSED( void )
 {
-	PRINT_NOT_IMPLEMENTED();
+	/* Unused in Vulkan renderer. GL renderer only uses this to populate r_speeds_msg string. In Vulkan this is done naturally in R_EndFrame */
 }
 
 // debug
@@ -361,12 +362,7 @@ static void		GL_OrthoBounds( const float *mins, const float *maxs )
 {
 	PRINT_NOT_IMPLEMENTED();
 }
-// grab r_speeds message
-static qboolean	R_SpeedsMessage( char *out, size_t size )
-{
-	PRINT_NOT_IMPLEMENTED();
-	return false;
-}
+
 // get visdata for current frame from custom renderer
 static byte*		Mod_GetCurrentVis( void )
 {
@@ -482,8 +478,8 @@ static const ref_interface_t gReffuncs =
 	R_EndFrame,
 	R_PushScene,
 	R_PopScene,
-	GL_BackendStartFrame,
-	GL_BackendEndFrame,
+	.GL_BackendStartFrame = GL_BackendStartFrame_UNUSED,
+	.GL_BackendEndFrame = GL_BackendEndFrame_UNUSED,
 
 	R_ClearScreen,
 	R_AllowFog,
@@ -579,7 +575,7 @@ static const ref_interface_t gReffuncs =
 
 	VK_RenderFrame,
 	GL_OrthoBounds,
-	R_SpeedsMessage,
+	.R_SpeedsMessage = R_SpeedsMessage,
 	Mod_GetCurrentVis,
 	R_NewMap,
 	R_ClearScene,

--- a/ref/vk/vk_staging.c
+++ b/ref/vk/vk_staging.c
@@ -2,6 +2,7 @@
 #include "vk_buffer.h"
 #include "alolcator.h"
 #include "vk_commandpool.h"
+#include "profiler.h"
 
 #include <memory.h>
 
@@ -52,9 +53,11 @@ void R_VkStagingShutdown(void) {
 }
 
 void R_VkStagingFlushSync( void ) {
+	APROF_SCOPE_DECLARE_BEGIN(__FUNCTION__, __FUNCTION__);
+
 	const VkCommandBuffer cmdbuf = R_VkStagingCommit();
 	if (!cmdbuf)
-		return;
+		goto end;
 
 	XVK_CHECK(vkEndCommandBuffer(cmdbuf));
 	g_staging.cmdbuf = VK_NULL_HANDLE;
@@ -75,6 +78,9 @@ void R_VkStagingFlushSync( void ) {
 	g_staging.buffers.count = 0;
 	g_staging.images.count = 0;
 	R_FlippingBuffer_Clear(&g_staging.buffer_alloc);
+
+end:
+	APROF_SCOPE_END(__FUNCTION__);
 };
 
 static uint32_t allocateInRing(uint32_t size, uint32_t alignment) {

--- a/ref/vk/vk_staging.c
+++ b/ref/vk/vk_staging.c
@@ -53,7 +53,7 @@ void R_VkStagingShutdown(void) {
 }
 
 void R_VkStagingFlushSync( void ) {
-	APROF_SCOPE_DECLARE_BEGIN(__FUNCTION__, __FUNCTION__);
+	APROF_SCOPE_DECLARE_BEGIN(function, __FUNCTION__);
 
 	const VkCommandBuffer cmdbuf = R_VkStagingCommit();
 	if (!cmdbuf)
@@ -82,7 +82,7 @@ void R_VkStagingFlushSync( void ) {
 	R_FlippingBuffer_Clear(&g_staging.buffer_alloc);
 
 end:
-	APROF_SCOPE_END(__FUNCTION__);
+	APROF_SCOPE_END(function);
 };
 
 static uint32_t allocateInRing(uint32_t size, uint32_t alignment) {

--- a/ref/vk/vk_staging.c
+++ b/ref/vk/vk_staging.c
@@ -64,16 +64,18 @@ void R_VkStagingFlushSync( void ) {
 
 	//gEngine.Con_Reportf(S_WARN "flushing staging buffer img count=%d\n", g_staging.images.count);
 
-	const VkSubmitInfo subinfo = {
-		.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
-		.commandBufferCount = 1,
-		.pCommandBuffers = &cmdbuf,
-	};
+	{
+		const VkSubmitInfo subinfo = {
+			.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+			.commandBufferCount = 1,
+			.pCommandBuffers = &cmdbuf,
+		};
 
-	// TODO wait for previous command buffer completion. Why: we might end up writing into the same dst
+		// TODO wait for previous command buffer completion. Why: we might end up writing into the same dst
 
-	XVK_CHECK(vkQueueSubmit(vk_core.queue, 1, &subinfo, VK_NULL_HANDLE));
-	XVK_CHECK(vkQueueWaitIdle(vk_core.queue));
+		XVK_CHECK(vkQueueSubmit(vk_core.queue, 1, &subinfo, VK_NULL_HANDLE));
+		XVK_CHECK(vkQueueWaitIdle(vk_core.queue));
+	}
 
 	g_staging.buffers.count = 0;
 	g_staging.images.count = 0;

--- a/ref/vk/vk_studio.c
+++ b/ref/vk/vk_studio.c
@@ -6,6 +6,7 @@
 #include "vk_previous_frame.h"
 #include "vk_renderstate.h"
 #include "vk_math.h"
+#include "vk_cvar.h"
 #include "camera.h"
 
 #include "xash3d_mathlib.h"
@@ -38,8 +39,6 @@ typedef struct
 	char		modelname[MAX_OSPATH];
 	model_t		*model;
 } player_model_t;
-
-cvar_t *r_glowshellfreq;
 
 cvar_t r_shadows = { (char*)"r_shadows", (char*)"0", 0 };
 
@@ -116,9 +115,7 @@ typedef struct
 } studio_draw_state_t;
 
 // studio-related cvars
-static cvar_t			*r_drawviewmodel;
 cvar_t			*cl_righthand = NULL;
-static cvar_t			*cl_himodels;
 
 static r_studio_interface_t	*pStudioDraw;
 static studio_draw_state_t	g_studio;		// global studio state
@@ -144,11 +141,7 @@ static struct {
 
 void R_StudioInit( void )
 {
-	cl_himodels = gEngine.pfnGetCvarPointer( "cl_himodels", 0 );
-	r_drawviewmodel = gEngine.Cvar_Get( "r_drawviewmodel", "1", 0, "draw firstperson weapon model" );
-
 	Matrix3x4_LoadIdentity( g_studio.rotationmatrix );
-	r_glowshellfreq = gEngine.Cvar_Get( "r_glowshellfreq", "2.2", 0, "glowing shell frequency update" );
 
 	// g-cont. cvar disabled by Valve
 //	gEngine.Cvar_RegisterVariable( &r_shadows );

--- a/ref/vk/vk_swapchain.c
+++ b/ref/vk/vk_swapchain.c
@@ -193,7 +193,7 @@ void R_VkSwapchainShutdown( void ) {
 }
 
 r_vk_swapchain_framebuffer_t R_VkSwapchainAcquire(  VkSemaphore sem_image_available ) {
-	APROF_SCOPE_DECLARE_BEGIN(__FUNCTION__, __FUNCTION__);
+	APROF_SCOPE_DECLARE_BEGIN(function, __FUNCTION__);
 
 	r_vk_swapchain_framebuffer_t ret = {0};
 	qboolean force_recreate = false;
@@ -236,7 +236,7 @@ r_vk_swapchain_framebuffer_t R_VkSwapchainAcquire(  VkSemaphore sem_image_availa
 	ret.image = g_swapchain.images[ret.index];
 	ret.view = g_swapchain.image_views[ret.index];
 
-	APROF_SCOPE_END(__FUNCTION__);
+	APROF_SCOPE_END(function);
 
 	return ret;
 }

--- a/ref/vk/vk_swapchain.c
+++ b/ref/vk/vk_swapchain.c
@@ -1,5 +1,6 @@
 #include "vk_swapchain.h"
 #include "vk_image.h"
+#include "profiler.h"
 
 #include "eiface.h" // ARRAYSIZE
 
@@ -98,6 +99,7 @@ qboolean recreateSwapchain( qboolean force ) {
 			.preTransform = surface_caps.currentTransform,
 			.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
 			.presentMode = VK_PRESENT_MODE_FIFO_KHR, // TODO caps, MAILBOX is better
+			//.presentMode = VK_PRESENT_MODE_MAILBOX_KHR, // TODO caps, MAILBOX is better
 			//.presentMode = VK_PRESENT_MODE_IMMEDIATE_KHR, // TODO caps, MAILBOX is better
 			.clipped = VK_TRUE,
 			.oldSwapchain = g_swapchain.swapchain,
@@ -191,6 +193,12 @@ void R_VkSwapchainShutdown( void ) {
 }
 
 r_vk_swapchain_framebuffer_t R_VkSwapchainAcquire(  VkSemaphore sem_image_available ) {
+	static int _aprof_scope_id_scope = -1;
+	if (_aprof_scope_id_scope == -1)
+		_aprof_scope_id_scope = aprof_scope_init(__FUNCTION__);
+
+	APROF_SCOPE_BEGIN(scope);
+
 	r_vk_swapchain_framebuffer_t ret = {0};
 	qboolean force_recreate = false;
 
@@ -228,6 +236,8 @@ r_vk_swapchain_framebuffer_t R_VkSwapchainAcquire(  VkSemaphore sem_image_availa
 	ret.height = g_swapchain.height;
 	ret.image = g_swapchain.images[ret.index];
 	ret.view = g_swapchain.image_views[ret.index];
+
+	APROF_SCOPE_END(scope);
 
 	return ret;
 }

--- a/ref/vk/vk_swapchain.c
+++ b/ref/vk/vk_swapchain.c
@@ -193,11 +193,7 @@ void R_VkSwapchainShutdown( void ) {
 }
 
 r_vk_swapchain_framebuffer_t R_VkSwapchainAcquire(  VkSemaphore sem_image_available ) {
-	static int _aprof_scope_id_scope = -1;
-	if (_aprof_scope_id_scope == -1)
-		_aprof_scope_id_scope = aprof_scope_init(__FUNCTION__);
-
-	APROF_SCOPE_BEGIN(scope);
+	APROF_SCOPE_DECLARE_BEGIN(__FUNCTION__, __FUNCTION__);
 
 	r_vk_swapchain_framebuffer_t ret = {0};
 	qboolean force_recreate = false;
@@ -237,7 +233,7 @@ r_vk_swapchain_framebuffer_t R_VkSwapchainAcquire(  VkSemaphore sem_image_availa
 	ret.image = g_swapchain.images[ret.index];
 	ret.view = g_swapchain.image_views[ret.index];
 
-	APROF_SCOPE_END(scope);
+	APROF_SCOPE_END(__FUNCTION__);
 
 	return ret;
 }

--- a/ref/vk/vk_swapchain.c
+++ b/ref/vk/vk_swapchain.c
@@ -202,7 +202,10 @@ r_vk_swapchain_framebuffer_t R_VkSwapchainAcquire(  VkSemaphore sem_image_availa
 		// Check that swapchain has the same size
 		recreateSwapchain(force_recreate);
 
+		APROF_SCOPE_DECLARE_BEGIN_EX(vkAcquireNextImageKHR, "vkAcquireNextImageKHR", APROF_SCOPE_FLAG_WAIT);
 		const VkResult acquire_result = vkAcquireNextImageKHR(vk_core.device, g_swapchain.swapchain, UINT64_MAX, sem_image_available, VK_NULL_HANDLE, &ret.index);
+		APROF_SCOPE_END(vkAcquireNextImageKHR);
+
 		switch (acquire_result) {
 			case VK_SUCCESS:
 				break;


### PR DESCRIPTION
- [x] Convert direct stack manipulation to simple and cheap event writing. Draw rudimentary frame times graph.
- [x] Control perf display with `r_speeds`
- [x] Prepare r_speeds_msg string
- [x] (1) Basic frame stats: last overall frame time, GPU time, ref CPU time
- ~(2) Basic counters: brush models, studio models, BLASes, sprites, beams, lights (static+dynamic, polygons and vertices), data sizes and rates, staging uploads counts, etc.~
  - -> #483 
- ~(4) GPU usage info~
  - -> #484
- ~GPU timestamp markers/scopes~
  - -> #485
- ~Graphs for all metrics~
- ~Percentiles for all metrics~
- ~Graphs for metric percentiles~
  - -> #486 
- ~Export to chrome://trace or other similar formats~
  - -> #487 

Fixes #412