### PR TITLE
vk: profiler: start implementing universal metric graphs

### DIFF
--- a/ref/vk/r_speeds.c
+++ b/ref/vk/r_speeds.c
@@ -245,14 +245,15 @@ static void handlePause( uint32_t prev_frame_index ) {
 
 static int drawGraph( r_speeds_graph_t *const graph, int frame_bar_y ) {
 	const float width = (float)vk_frame.width / graph->data_count;
-	const float height_scale = (float)graph->height / graph->max_value;
+	const float graph_height = graph->height * g_speeds.font_metrics.scale;
+	const float height_scale = graph_height / graph->max_value;
 
-	CL_FillRGBABlend(0, frame_bar_y, vk_frame.width, graph->height, graph->color[0], graph->color[1], graph->color[2], 32);
+	CL_FillRGBABlend(0, frame_bar_y, vk_frame.width, graph_height, graph->color[0], graph->color[1], graph->color[2], 32);
 
 	const char *name = g_speeds.metrics[graph->source_metric].name;
 	rgba_t text_color = {0xed, 0x9f, 0x01, 0xff};
 	gEngine.Con_DrawString(0, frame_bar_y, name, text_color);
-	gEngine.Con_DrawString(0, frame_bar_y + graph->height - g_speeds.font_metrics.glyph_height, "0", text_color);
+	gEngine.Con_DrawString(0, frame_bar_y + graph_height - g_speeds.font_metrics.glyph_height, "0", text_color);
 
 	{
 		char buf[16];
@@ -260,7 +261,7 @@ static int drawGraph( r_speeds_graph_t *const graph, int frame_bar_y ) {
 		gEngine.Con_DrawString(0, frame_bar_y + g_speeds.font_metrics.glyph_height, buf, text_color);
 	}
 
-	frame_bar_y += graph->height;
+	frame_bar_y += graph_height;
 
 
 
@@ -287,7 +288,7 @@ static int drawGraph( r_speeds_graph_t *const graph, int frame_bar_y ) {
 		const int x0 = (float)i * width;
 		const int x1 = (float)(i+1) * width;
 		const int y_pos = value * height_scale;
-		const int height = 2; //value * height_scale;
+		const int height = 2 * g_speeds.font_metrics.scale;
 		const int y = frame_bar_y - y_pos;
 
 		CL_FillRGBA(x0, y, x1-x0, height, red, green, blue, 127);
@@ -436,7 +437,7 @@ static void speedsGraphAddByMetricName( const_string_view_t name ) {
 
 	// TODO make these customizable
 	graph->data_count = 256;
-	graph->height = 100 * g_speeds.font_metrics.scale;
+	graph->height = 100;
 	graph->max_value = 1; // Will be computed automatically on first frame
 	graph->color[3] = 255;
 	getColorForString(metric->name, graph->color);

--- a/ref/vk/vk_common.h
+++ b/ref/vk/vk_common.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "const.h" // required for ref_api.h
 #include "cvardef.h"
 #include "com_model.h"
@@ -47,6 +49,12 @@
 #define ALIGN_UP(ptr, align) ((((ptr) + (align) - 1) / (align)) * (align))
 
 #define COUNTOF(a) (sizeof(a)/sizeof((a)[0]))
+
+inline static int clampi32(int v, int min, int max) {
+	if (v < min) return min;
+	if (v > max) return max;
+	return v;
+}
 
 extern ref_api_t gEngine;
 extern ref_globals_t *gpGlobals;

--- a/ref/vk/vk_triapi.c
+++ b/ref/vk/vk_triapi.c
@@ -217,12 +217,6 @@ void TriVertex3f( float x, float y, float z ) {
 	g_triapi.vertices[g_triapi.num_vertices] = g_triapi.vertices[g_triapi.num_vertices-1];
 }
 
-static int clampi32(int v, int min, int max) {
-	if (v < min) return min;
-	if (v > max) return max;
-	return v;
-}
-
 void TriColor4ub_( byte r, byte g, byte b, byte a ) {
 	Vector4Set(g_triapi.vertices[g_triapi.num_vertices].color, r, g, b, a);
 }


### PR DESCRIPTION
- [x] Graph range modes:
  - [x] Automatic: by max value, or by max percentile (e.g. so that 95% of points are below the limit)
  - [x] Hardcoded for frame time
  - [ ] ~~Fixed: range is specified externally~~ low priority 
- [x] Watermarks and colors. E.g. frame time <16.6ms is green >33.3ms is red
- [x] Saving selection of metrics to graph between reloads. Specify them as cvar, not a command?
- [ ] ~~Plot by lines, not by rects~~ low priority (#494)

Fixes #486 