### PR TITLE
rt: remove freeze_models functionality

### DIFF
--- a/ref/vk/vk_ray_internal.h
+++ b/ref/vk/vk_ray_internal.h
@@ -71,8 +71,6 @@ typedef struct {
 	} frame;
 
 	vk_ray_model_t models_cache[MODEL_CACHE_SIZE];
-
-	qboolean freeze_models;
 } xvk_ray_model_state_t;
 
 extern xvk_ray_model_state_t g_ray_model_state;

--- a/ref/vk/vk_ray_model.c
+++ b/ref/vk/vk_ray_model.c
@@ -220,9 +220,6 @@ vk_ray_model_t* VK_RayModelCreate( vk_ray_model_init_t args ) {
 
 	ASSERT(vk_core.rtx);
 
-	if (g_ray_model_state.freeze_models)
-		return args.model->ray_model;
-
 	if (kusochki_count_offset == ALO_ALLOC_FAILED) {
 		gEngine.Con_Printf(S_ERROR "Maximum number of kusochki exceeded on model %s\n", args.model->debug_name);
 		return NULL;
@@ -400,8 +397,6 @@ vk_ray_model_t* VK_RayModelCreate( vk_ray_model_init_t args ) {
 }
 
 void VK_RayModelDestroy( struct vk_ray_model_s *model ) {
-	ASSERT(!g_ray_model_state.freeze_models);
-
 	ASSERT(vk_core.rtx);
 	if (model->as != VK_NULL_HANDLE) {
 		//gEngine.Con_Reportf("Model %s destroying AS=%p blas_index=%d\n", model->debug_name, model->rtx.blas, blas_index);
@@ -447,9 +442,6 @@ void VK_RayFrameAddModel( vk_ray_model_t *model, const vk_render_model_t *render
 	ASSERT(vk_core.rtx);
 	ASSERT(g_ray_model_state.frame.num_models <= ARRAYSIZE(g_ray_model_state.frame.models));
 	ASSERT(model->num_geoms == render_model->num_geometries);
-
-	if (g_ray_model_state.freeze_models)
-		return;
 
 	if (g_ray_model_state.frame.num_models == ARRAYSIZE(g_ray_model_state.frame.models)) {
 		gEngine.Con_Printf(S_ERROR "Ran out of AccelerationStructure slots\n");

--- a/ref/vk/vk_rtx.c
+++ b/ref/vk/vk_rtx.c
@@ -133,15 +133,8 @@ void VK_RayFrameBegin( void ) {
 	ASSERT(vk_core.rtx);
 
 	RT_VkAccelFrameBegin();
-
-	if (g_ray_model_state.freeze_models)
-		return;
-
 	XVK_RayModel_ClearForNextFrame();
-
 	R_PrevFrame_StartFrame();
-
-	// TODO shouldn't we do this in freeze models mode anyway?
 	RT_LightsFrameBegin();
 }
 
@@ -597,10 +590,6 @@ static void reloadPipeline( void ) {
 	g_rtx.reload_pipeline = true;
 }
 
-static void freezeModels( void ) {
-	g_ray_model_state.freeze_models = !g_ray_model_state.freeze_models;
-}
-
 qboolean VK_RayInit( void )
 {
 	ASSERT(vk_core.rtx);
@@ -645,7 +634,6 @@ qboolean VK_RayInit( void )
 	RT_RayModel_Clear();
 
 	gEngine.Cmd_AddCommand("vk_rtx_reload", reloadPipeline, "Reload RTX shader");
-	gEngine.Cmd_AddCommand("vk_rtx_freeze", freezeModels, "Freeze models, do not update/add/delete models from to-draw list");
 
 	return true;
 }


### PR DESCRIPTION
It's been obsolete and broken for many months now.

Fixes #509