### PR TITLE
Make func_wall lights static, and also allow patching their offsets

### DIFF
--- a/ref/vk/vk_brush.c
+++ b/ref/vk/vk_brush.c
@@ -853,7 +853,7 @@ void R_VkBrushModelCollectEmissiveSurfaces( const struct model_s *mod, qboolean 
 			polylight.dynamic = true;
 			matrix3x4 m;
 			Matrix3x4_LoadIdentity(m);
-			Matrix3x4_SetOrigin(m, func_wall->offset[0], func_wall->offset[1], func_wall->offset[2]);
+			Matrix3x4_SetOrigin(m, func_wall->origin[0], func_wall->origin[1], func_wall->origin[2]);
 			polylight.transform_row = &m;
 		}
 

--- a/ref/vk/vk_mapents.c
+++ b/ref/vk/vk_mapents.c
@@ -348,12 +348,12 @@ static void readFuncWall( const entity_props_t *const props, uint32_t have_field
 
 	*e = (xvk_mapent_func_wall_t){0};
 
+	Q_strcpy(e->model, props->model);
+
 	/* NOTE: not used
 	e->rendercolor.r = 255;
 	e->rendercolor.g = 255;
 	e->rendercolor.b = 255;
-
-	Q_strcpy(e->model, props->model);
 
 	if (have_fields & Field_renderamt)
 		e->renderamt = props->renderamt;

--- a/ref/vk/vk_mapents.c
+++ b/ref/vk/vk_mapents.c
@@ -334,6 +334,7 @@ static void readFuncWall( const entity_props_t *const props, uint32_t have_field
 	xvk_mapent_func_wall_t *const e = g_map_entities.func_walls + (g_map_entities.func_walls_count++);
 
 	*e = (xvk_mapent_func_wall_t){0};
+
 	e->rendercolor.r = 255;
 	e->rendercolor.g = 255;
 	e->rendercolor.b = 255;
@@ -346,7 +347,6 @@ static void readFuncWall( const entity_props_t *const props, uint32_t have_field
 	if (have_fields & Field_renderfx)
 		e->renderfx = props->renderfx;
 
-
 	if (have_fields & Field_rendermode)
 		e->rendermode = props->rendermode;
 
@@ -355,6 +355,8 @@ static void readFuncWall( const entity_props_t *const props, uint32_t have_field
 		e->rendercolor.g = props->rendercolor[1];
 		e->rendercolor.b = props->rendercolor[2];
 	}
+
+	e->entity_index = g_map_entities.entity_count;
 }
 
 static void addPatchSurface( const entity_props_t *props, uint32_t have_fields ) {

--- a/ref/vk/vk_mapents.h
+++ b/ref/vk/vk_mapents.h
@@ -23,6 +23,12 @@
 	X(18, vec4_t, _xvk_tvec, Vec4) \
 	X(19, vec2_t, _xvk_tex_offset, Vec2) \
 	X(20, vec2_t, _xvk_tex_scale, Vec2) \
+	X(21, string, model, String) \
+	X(22, int, rendermode, Int) \
+	X(23, int, renderamt, Int) \
+	X(24, vec3_t, rendercolor, Vec3) \
+	X(25, int, renderfx, Int) \
+	X(26, vec3_t, _xvk_offset, Vec3) \
 
 typedef enum {
 	Unknown = 0,
@@ -30,6 +36,7 @@ typedef enum {
 	LightSpot,
 	LightEnvironment,
 	Worldspawn,
+	FuncWall,
 	Ignored,
 } class_name_e;
 
@@ -79,6 +86,15 @@ typedef struct {
 #define MAX_MAPENT_TARGETS 256
 
 typedef struct {
+	string model;
+	int rendermode, renderamt, renderfx;
+	color24 rendercolor;
+
+	struct cl_entity_s *ent;
+	vec3_t offset;
+} xvk_mapent_func_wall_t;
+
+typedef struct {
 	int num_lights;
 	vk_light_entity_t lights[256];
 
@@ -89,6 +105,10 @@ typedef struct {
 
 	int num_targets;
 	xvk_mapent_target_t targets[MAX_MAPENT_TARGETS];
+
+#define MAX_FUNC_WALL_ENTITIES 64
+	int func_walls_count;
+	xvk_mapent_func_wall_t func_walls[MAX_FUNC_WALL_ENTITIES];
 } xvk_map_entities_t;
 
 extern xvk_map_entities_t g_map_entities;

--- a/ref/vk/vk_mapents.h
+++ b/ref/vk/vk_mapents.h
@@ -1,5 +1,7 @@
 #pragma once
 #include "xash3d_types.h"
+#include "const.h" // typedef word, needed for bspfile.h
+#include "bspfile.h" // MAX_MAP_ENTITIES
 
 #define ENT_PROP_LIST(X) \
 	X(0, vec3_t, origin, Vec3) \
@@ -24,11 +26,14 @@
 	X(19, vec2_t, _xvk_tex_offset, Vec2) \
 	X(20, vec2_t, _xvk_tex_scale, Vec2) \
 	X(21, string, model, String) \
+
+/* NOTE: not used
 	X(22, int, rendermode, Int) \
 	X(23, int, renderamt, Int) \
 	X(24, vec3_t, rendercolor, Vec3) \
 	X(25, int, renderfx, Int) \
 	X(26, vec3_t, _xvk_offset, Vec3) \
+*/
 
 typedef enum {
 	Unknown = 0,
@@ -38,6 +43,7 @@ typedef enum {
 	Worldspawn,
 	FuncWall,
 	Ignored,
+	Xvk_Target,
 } class_name_e;
 
 #define MAX_INT_ARRAY_SIZE 64
@@ -88,12 +94,20 @@ typedef struct {
 typedef struct {
 	int entity_index;
 	string model;
+	vec3_t origin;
+
+	/* NOTE: not used. Might be needed for #118 in the future.
 	int rendermode, renderamt, renderfx;
 	color24 rendercolor;
 
 	struct cl_entity_s *ent;
-	vec3_t offset;
+	*/
 } xvk_mapent_func_wall_t;
+
+typedef struct {
+	class_name_e class;
+	int index;
+} xvk_mapent_ref_t;
 
 typedef struct {
 	int num_lights;
@@ -110,6 +124,10 @@ typedef struct {
 #define MAX_FUNC_WALL_ENTITIES 64
 	int func_walls_count;
 	xvk_mapent_func_wall_t func_walls[MAX_FUNC_WALL_ENTITIES];
+
+	// TODO find out how to read this from the engine, or make its size dynamic
+//#define MAX_MAP_ENTITIES 2048
+	xvk_mapent_ref_t refs[MAX_MAP_ENTITIES];
 } xvk_map_entities_t;
 
 extern xvk_map_entities_t g_map_entities;

--- a/ref/vk/vk_mapents.h
+++ b/ref/vk/vk_mapents.h
@@ -86,6 +86,7 @@ typedef struct {
 #define MAX_MAPENT_TARGETS 256
 
 typedef struct {
+	int entity_index;
 	string model;
 	int rendermode, renderamt, renderfx;
 	color24 rendercolor;

--- a/ref/vk/vk_render.c
+++ b/ref/vk/vk_render.c
@@ -700,7 +700,8 @@ qboolean VK_RenderModelInit( vk_render_model_t *model ) {
 void VK_RenderModelDestroy( vk_render_model_t* model ) {
 	// FIXME why the condition? we should do the cleanup anyway
 	if (vk_core.rtx && (g_render_state.current_frame_is_ray_traced || !model->dynamic)) {
-		VK_RayModelDestroy(model->ray_model);
+		if (model->ray_model)
+			VK_RayModelDestroy(model->ray_model);
 		if (model->dynamic_polylights)
 			Mem_Free(model->dynamic_polylights);
 	}

--- a/ref/vk/vk_scene.c
+++ b/ref/vk/vk_scene.c
@@ -576,6 +576,16 @@ static void drawEntity( cl_entity_t *ent, int render_mode )
 	{
 		case mod_brush:
 			R_RotateForEntity( model, ent );
+
+			// Patch func_wall offsets
+			// TODO universal entity patching by index O(1); don't loop like that
+			for (int i = 0; i < g_map_entities.func_walls_count; ++i) {
+				xvk_mapent_func_wall_t *const fw = g_map_entities.func_walls + i;
+				if (fw->entity_index == ent->index + 1) {
+					Matrix4x4_ConcatTranslate(model, fw->offset[0], fw->offset[1], fw->offset[2]);
+					break;
+				}
+			}
 			VK_RenderStateSetMatrixModel( model );
 			VK_BrushModelDraw( ent, render_mode, blend, model );
 			break;

--- a/ref/vk/vk_scene.c
+++ b/ref/vk/vk_scene.c
@@ -577,31 +577,17 @@ static void drawEntity( cl_entity_t *ent, int render_mode )
 		case mod_brush:
 			R_RotateForEntity( model, ent );
 
-			{
-				// Patch func_wall entities offsets
-				const int eindex = ent->index + 1; // TODO why is this off-by-1?
-				const xvk_mapent_func_wall_t *func_wall = NULL;
-				if (eindex >= 0 && eindex < g_map_entities.entity_count) {
-					const xvk_mapent_ref_t *const ref = g_map_entities.refs + eindex;
-					if (ref->class == FuncWall) {
-						func_wall = g_map_entities.func_walls + ref->index;
-					} else {
-						// Not found directly by index, find otherwise
-						// TODO this should be removed after we make sure the the index method above is enough
-						// FIXME nope, indexes are not stable
-						for (int i = 0; i < g_map_entities.func_walls_count; ++i) {
-							xvk_mapent_func_wall_t *const fw = g_map_entities.func_walls + i;
-							if (Q_strcmp(ent->model->name, fw->model) == 0) {
-								gEngine.Con_Printf(S_ERROR "Entity %s is func_wall=%d, but its ent->index=%d(+1=%d) is off (mapents: %d)\n", ent->model->name, i, ent->index, eindex, fw->entity_index);
-								//func_wall = fw;
-								break;
-							}
-						}
-					}
-
-					if (func_wall) {
+			// If this is potentially a func_wall model
+			if (ent->model->name[0] == '*') {
+				for (int i = 0; i < g_map_entities.func_walls_count; ++i) {
+					xvk_mapent_func_wall_t *const fw = g_map_entities.func_walls + i;
+					if (Q_strcmp(ent->model->name, fw->model) == 0) {
+						/* gEngine.Con_Reportf("ent->index=%d (%s) mapent:%d off=%f %f %f\n", */
+						/* 		ent->index, ent->model->name, fw->entity_index, */
+						/* 		fw->origin[0], fw->origin[1], fw->origin[2]); */
 						Matrix3x4_LoadIdentity(model);
-						Matrix4x4_SetOrigin(model, func_wall->origin[0], func_wall->origin[1], func_wall->origin[2]);
+						Matrix4x4_SetOrigin(model, fw->origin[0], fw->origin[1], fw->origin[2]);
+						break;
 					}
 				}
 			}


### PR DESCRIPTION
- [x] Fixes #415: extracts `func_wall` light sources as static.
- [x] Fixes #335: allows patching `func_wall` entities offsets.