### PR TITLE
ci: temporarily disable the nswitch target

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -19,6 +19,7 @@ jobs:
           - os: ubuntu-20.04
             targetos: linux
             targetarch: i386
+# TODO enable and test ref_vk for it too
 #          - os: ubuntu-aarch64-20.04
 #            targetos: linux
 #            targetarch: aarch64
@@ -34,9 +35,11 @@ jobs:
 #            targetos: motomagx
 #            targetarch: armv6
 
-          - os: ubuntu-20.04
-            targetos: nswitch
-            targetarch: arm64
+# FIXME suddenly started failing, disable temporarily as irrelevant for ref_vk effort
+#          - os: ubuntu-20.04
+#            targetos: nswitch
+#            targetarch: arm64
+
           - os: windows-latest
             targetos: win32
             targetarch: amd64


### PR DESCRIPTION
It started failing suddenly w/o any changes on our part. It is irrelevant for this fork, so disable it for now.