### PR TITLE
Smooth brush surface normals

### DIFF
--- a/ref/vk/shaders/denoiser.comp
+++ b/ref/vk/shaders/denoiser.comp
@@ -36,12 +36,14 @@ layout(set = 0, binding = 15, rgba16f) uniform image2D prev_temporal_diffuse;
 layout(set = 0, binding = 16, rgba16f) uniform image2D out_temporal_specular;
 layout(set = 0, binding = 17, rgba16f) uniform image2D prev_temporal_specular;
 
+
 const int INDIRECT_SCALE = 2;
 
 //#define DEBUG_TEXTURE normals_gs
 //#define DEBUG_TEXTURE emissive
 //#define DEBUG_TEXTURE light_point_diffuse
 //#define DEBUG_NORMAL
+//layout(set = 0, binding = 18, rgba8) uniform readonly image2D material_rmxx;
 
 // Blatantly copypasted from https://www.shadertoy.com/view/XsGfWV
 vec3 aces_tonemap(vec3 color){
@@ -202,7 +204,11 @@ void main() {
 	vec3 geometry_normal, shading_normal;
 	readNormals(pix, geometry_normal, shading_normal);
 	//imageStore(out_dest, pix, vec4(.5 + geometry_normal * .5, 0.)); return;
-	imageStore(out_dest, pix, vec4(.5 + shading_normal * .5, 0.)); return;
+	//const vec4 mat_rmxx = imageLoad(material_rmxx, pix);
+	//imageStore(out_dest, pix, vec4((.5 + shading_normal * .5)*.8 + .2 * mat_rmxx.a , 0.)); return;
+
+	vec3 normal = pix.x < res.x / 2 ? shading_normal : geometry_normal;
+	imageStore(out_dest, pix, vec4(.5 + normal * .5, 0.)); return;
 #endif
 
 	/* const uint mi = uint(material_index); */

--- a/ref/vk/shaders/denoiser.comp
+++ b/ref/vk/shaders/denoiser.comp
@@ -41,6 +41,7 @@ const int INDIRECT_SCALE = 2;
 //#define DEBUG_TEXTURE normals_gs
 //#define DEBUG_TEXTURE emissive
 //#define DEBUG_TEXTURE light_point_diffuse
+//#define DEBUG_NORMAL
 
 // Blatantly copypasted from https://www.shadertoy.com/view/XsGfWV
 vec3 aces_tonemap(vec3 color){
@@ -197,7 +198,7 @@ void main() {
 	//imageStore(out_dest, pix, vec4(fract(imageLoad(position_t, pix).rgb/10.), 0.)); return;
 	//imageStore(out_dest, pix, vec4(fract(imageLoad(geometry_prev_position, pix).rgb/50.), 0.)); return;
 
-#if 0
+#if defined(DEBUG_NORMAL)
 	vec3 geometry_normal, shading_normal;
 	readNormals(pix, geometry_normal, shading_normal);
 	//imageStore(out_dest, pix, vec4(.5 + geometry_normal * .5, 0.)); return;

--- a/ref/vk/shaders/ray_primary.comp
+++ b/ref/vk/shaders/ray_primary.comp
@@ -8,6 +8,7 @@ layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
 
 #include "ray_primary_common.glsl"
 #include "ray_primary_hit.glsl"
+//#include "noise.glsl"
 
 #define RAY_PRIMARY_OUTPUTS(X) \
 	X(10, base_color_a, rgba8) \
@@ -97,8 +98,10 @@ void main() {
 	}
 
 	float L = ray.dist;
-
+	//uint debug_geometry_index = 0;
 	if (rayQueryGetIntersectionTypeEXT(rq, true) == gl_RayQueryCommittedIntersectionTriangleEXT) {
+		//debug_geometry_index = rayQueryGetIntersectionGeometryIndexEXT(rq, true);
+		//debug_geometry_index = rayQueryGetIntersectionPrimitiveIndexEXT(rq, true);
 		primaryRayHit(rq, payload);
 		L = rayQueryGetIntersectionTEXT(rq, true);
 	}
@@ -108,6 +111,7 @@ void main() {
 	imageStore(out_position_t, pix, payload.hit_t);
 	imageStore(out_base_color_a, pix, payload.base_color_a);
 	imageStore(out_normals_gs, pix, payload.normals_gs);
+	//imageStore(out_material_rmxx, pix, vec4(payload.material_rmxx.rg, 0, uintToFloat01(xxhash32(debug_geometry_index))));
 	imageStore(out_material_rmxx, pix, payload.material_rmxx);
 	imageStore(out_emissive, pix, payload.emissive);
 	imageStore(out_geometry_prev_position, pix, payload.prev_pos_t);

--- a/ref/vk/vk_brush.c
+++ b/ref/vk/vk_brush.c
@@ -807,16 +807,10 @@ static qboolean shouldSmoothLinkSurfaces(const model_t* mod, int surf1, int surf
 	getSurfaceNormal(mod->surfaces + surf2, n2);
 
 	// TODO patch filtering
-	const float threshold = .7f;
-	return DotProduct(n1, n2) > threshold;
+	const float dot = DotProduct(n1, n2);
+	DEBUG("Smoothing: dot(%d, %d) = %f (t=%f)", surf1, surf2, dot, g_map_entities.smoothing_threshold);
 
-	/*
-	if (
-	((cedge->surfs[0] == 743 || cedge->surfs[1] == 743) &&
-	 (cedge->surfs[0] == 741 || cedge->surfs[1] == 741)) ||
-	((cedge->surfs[0] == 367 || cedge->surfs[1] == 367) &&
-	 (cedge->surfs[0] == 404 || cedge->surfs[1] == 404))) {
-	*/
+	return dot >= g_map_entities.smoothing_threshold;
 }
 
 static int lvFindValue(const linked_value_t *li, int count, int needle) {

--- a/ref/vk/vk_brush.c
+++ b/ref/vk/vk_brush.c
@@ -809,13 +809,21 @@ static int getSurfaceTexture(const msurface_t *surf, int surface_index) {
 static qboolean shouldSmoothLinkSurfaces(const model_t* mod, int surf1, int surf2) {
 	//return Q_min(surf1, surf2) == 741 && Q_max(surf1, surf2) == 743;
 
-	// TODO patch filtering
-
 	// Do not join surfaces with different textures. Assume they belong to different objects.
 	const int t1 = getSurfaceTexture(mod->surfaces + surf1, surf1);
 	const int t2 = getSurfaceTexture(mod->surfaces + surf2, surf2);
 	if (t1 != t2)
 		return false;
+
+	// Filter explicit exclusion
+	for (int i = 0; i < g_map_entities.smoothing.excluded_count; i+=2) {
+		const int cand1 = g_map_entities.smoothing.excluded[i];
+		const int cand2 = g_map_entities.smoothing.excluded[i+1];
+
+		if ((cand1 == surf1 && cand2 == surf2)
+			|| (cand1 == surf2 && cand2 == surf1))
+			return false;
+	}
 
 	vec3_t n1, n2;
 	getSurfaceNormal(mod->surfaces + surf1, n1);

--- a/ref/vk/vk_mapents.c
+++ b/ref/vk/vk_mapents.c
@@ -536,6 +536,24 @@ static void appendExludedPairs(const entity_props_t *props) {
 	g_map_entities.smoothing.excluded_count += count;
 }
 
+static void addSmoothingGroup(const entity_props_t *props) {
+	if (g_map_entities.smoothing.groups_count == MAX_INCLUDED_SMOOTHING_GROUPS) {
+		ERR("vk_mapents: limit of %d smoothing groups reached", MAX_INCLUDED_SMOOTHING_GROUPS);
+		return;
+	}
+
+	xvk_smoothing_group_t *g = g_map_entities.smoothing.groups + (g_map_entities.smoothing.groups_count++);
+
+	int count = props->_xvk_smoothing_group.num;
+	if (count > MAX_INCLUDED_SMOOTHING_SURFACES_IN_A_GROUP) {
+		ERR("vk_mapents: too many surfaces in a smoothing group. Max %d, got %d. Culling", MAX_INCLUDED_SMOOTHING_SURFACES_IN_A_GROUP, props->_xvk_smoothing_group.num);
+		count = MAX_INCLUDED_SMOOTHING_SURFACES_IN_A_GROUP;
+	}
+
+	memcpy(g->surfaces, props->_xvk_smoothing_group.values, sizeof(int) * count);
+	g->count = count;
+}
+
 static void parseEntities( char *string, qboolean is_patch ) {
 	unsigned have_fields = 0;
 	int props_count = 0;
@@ -592,6 +610,10 @@ static void parseEntities( char *string, qboolean is_patch ) {
 
 							if (have_fields & Field__xvk_smoothing_excluded_pairs) {
 								appendExludedPairs(&values);
+							}
+
+							if (have_fields & Field__xvk_smoothing_group) {
+								addSmoothingGroup(&values);
 							}
 						}
 					}

--- a/ref/vk/vk_mapents.c
+++ b/ref/vk/vk_mapents.c
@@ -571,7 +571,7 @@ static void parseEntities( char *string, qboolean is_patch ) {
 						} else if (have_fields & Field__xvk_ent_id) {
 							patchEntity( &values, have_fields );
 						} else if (have_fields & Field__xvk_smoothing_threshold) {
-							g_map_entities.smoothing_threshold = cosf(DEG2RAD(values._xvk_smoothing_threshold));
+							g_map_entities.smoothing.threshold = cosf(DEG2RAD(values._xvk_smoothing_threshold));
 						}
 					}
 					break;
@@ -678,7 +678,7 @@ void XVK_ParseMapEntities( void ) {
 	g_map_entities.single_environment_index = NoEnvironmentLights;
 	g_map_entities.entity_count = 0;
 	g_map_entities.func_walls_count = 0;
-	g_map_entities.smoothing_threshold = cosf(DEG2RAD(45.f));
+	g_map_entities.smoothing.threshold = cosf(DEG2RAD(45.f));
 
 	parseEntities( map->entities, false );
 	orientSpotlights();

--- a/ref/vk/vk_mapents.c
+++ b/ref/vk/vk_mapents.c
@@ -518,7 +518,22 @@ static void patchEntity( const entity_props_t *props, uint32_t have_fields ) {
 				WARN("vk_mapents: trying to patch unsupported entity %d class %d", ei, ref->class);
 		}
 	}
+}
 
+static void appendExludedPairs(const entity_props_t *props) {
+	if (props->_xvk_smoothing_excluded_pairs.num % 2 != 0) {
+		ERR("vk_mapents: smoothing group exclusion list should be list of pairs -- divisible by 2; cutting the tail");
+	}
+
+	int count = props->_xvk_smoothing_excluded_pairs.num & ~1;
+	if (g_map_entities.smoothing.excluded_count + count > COUNTOF(g_map_entities.smoothing.excluded)) {
+		ERR("vk_mapents: smoothing exclusion group capacity exceeded, go complain in github issues");
+		count = COUNTOF(g_map_entities.smoothing.excluded) - g_map_entities.smoothing.excluded_count;
+	}
+
+	memcpy(g_map_entities.smoothing.excluded + g_map_entities.smoothing.excluded_count, props->_xvk_smoothing_excluded_pairs.values, count * sizeof(int));
+
+	g_map_entities.smoothing.excluded_count += count;
 }
 
 static void parseEntities( char *string, qboolean is_patch ) {
@@ -570,8 +585,14 @@ static void parseEntities( char *string, qboolean is_patch ) {
 							addPatchSurface( &values, have_fields );
 						} else if (have_fields & Field__xvk_ent_id) {
 							patchEntity( &values, have_fields );
-						} else if (have_fields & Field__xvk_smoothing_threshold) {
-							g_map_entities.smoothing.threshold = cosf(DEG2RAD(values._xvk_smoothing_threshold));
+						} else {
+							if (have_fields & Field__xvk_smoothing_threshold) {
+								g_map_entities.smoothing.threshold = cosf(DEG2RAD(values._xvk_smoothing_threshold));
+							}
+
+							if (have_fields & Field__xvk_smoothing_excluded_pairs) {
+								appendExludedPairs(&values);
+							}
 						}
 					}
 					break;
@@ -679,6 +700,7 @@ void XVK_ParseMapEntities( void ) {
 	g_map_entities.entity_count = 0;
 	g_map_entities.func_walls_count = 0;
 	g_map_entities.smoothing.threshold = cosf(DEG2RAD(45.f));
+	g_map_entities.smoothing.excluded_count = 0;
 
 	parseEntities( map->entities, false );
 	orientSpotlights();

--- a/ref/vk/vk_mapents.c
+++ b/ref/vk/vk_mapents.c
@@ -570,6 +570,8 @@ static void parseEntities( char *string, qboolean is_patch ) {
 							addPatchSurface( &values, have_fields );
 						} else if (have_fields & Field__xvk_ent_id) {
 							patchEntity( &values, have_fields );
+						} else if (have_fields & Field__xvk_smoothing_threshold) {
+							g_map_entities.smoothing_threshold = cosf(DEG2RAD(values._xvk_smoothing_threshold));
 						}
 					}
 					break;
@@ -676,6 +678,7 @@ void XVK_ParseMapEntities( void ) {
 	g_map_entities.single_environment_index = NoEnvironmentLights;
 	g_map_entities.entity_count = 0;
 	g_map_entities.func_walls_count = 0;
+	g_map_entities.smoothing_threshold = cosf(DEG2RAD(45.f));
 
 	parseEntities( map->entities, false );
 	orientSpotlights();

--- a/ref/vk/vk_mapents.c
+++ b/ref/vk/vk_mapents.c
@@ -723,6 +723,9 @@ void XVK_ParseMapEntities( void ) {
 	g_map_entities.func_walls_count = 0;
 	g_map_entities.smoothing.threshold = cosf(DEG2RAD(45.f));
 	g_map_entities.smoothing.excluded_count = 0;
+	for (int i = 0; i < g_map_entities.smoothing.groups_count; ++i)
+		g_map_entities.smoothing.groups[i].count = 0;
+	g_map_entities.smoothing.groups_count = 0;
 
 	parseEntities( map->entities, false );
 	orientSpotlights();

--- a/ref/vk/vk_mapents.h
+++ b/ref/vk/vk_mapents.h
@@ -27,6 +27,7 @@
 	X(20, vec2_t, _xvk_tex_scale, Vec2) \
 	X(21, string, model, String) \
 	X(22, float, _xvk_smoothing_threshold, Float) \
+	X(23, int_array_t, _xvk_smoothing_excluded_pairs, IntArray) \
 
 /* NOTE: not used
 	X(22, int, rendermode, Int) \
@@ -132,6 +133,10 @@ typedef struct {
 
 	struct {
 		float threshold;
+
+#define MAX_EXCLUDED_SMOOTHING_SURFACES_PAIRS 32
+		int excluded[MAX_EXCLUDED_SMOOTHING_SURFACES_PAIRS * 2];
+		int excluded_count;
 	} smoothing;
 } xvk_map_entities_t;
 

--- a/ref/vk/vk_mapents.h
+++ b/ref/vk/vk_mapents.h
@@ -26,6 +26,7 @@
 	X(19, vec2_t, _xvk_tex_offset, Vec2) \
 	X(20, vec2_t, _xvk_tex_scale, Vec2) \
 	X(21, string, model, String) \
+	X(22, float, _xvk_smoothing_threshold, Float) \
 
 /* NOTE: not used
 	X(22, int, rendermode, Int) \
@@ -128,6 +129,8 @@ typedef struct {
 	// TODO find out how to read this from the engine, or make its size dynamic
 //#define MAX_MAP_ENTITIES 2048
 	xvk_mapent_ref_t refs[MAX_MAP_ENTITIES];
+
+	float smoothing_threshold;
 } xvk_map_entities_t;
 
 extern xvk_map_entities_t g_map_entities;

--- a/ref/vk/vk_mapents.h
+++ b/ref/vk/vk_mapents.h
@@ -130,7 +130,9 @@ typedef struct {
 //#define MAX_MAP_ENTITIES 2048
 	xvk_mapent_ref_t refs[MAX_MAP_ENTITIES];
 
-	float smoothing_threshold;
+	struct {
+		float threshold;
+	} smoothing;
 } xvk_map_entities_t;
 
 extern xvk_map_entities_t g_map_entities;

--- a/ref/vk/vk_mapents.h
+++ b/ref/vk/vk_mapents.h
@@ -28,6 +28,7 @@
 	X(21, string, model, String) \
 	X(22, float, _xvk_smoothing_threshold, Float) \
 	X(23, int_array_t, _xvk_smoothing_excluded_pairs, IntArray) \
+	X(24, int_array_t, _xvk_smoothing_group, IntArray) \
 
 /* NOTE: not used
 	X(22, int, rendermode, Int) \
@@ -111,6 +112,12 @@ typedef struct {
 	int index;
 } xvk_mapent_ref_t;
 
+#define MAX_INCLUDED_SMOOTHING_SURFACES_IN_A_GROUP 16
+typedef struct {
+	int count;
+	int surfaces[MAX_INCLUDED_SMOOTHING_SURFACES_IN_A_GROUP];
+} xvk_smoothing_group_t;
+
 typedef struct {
 	int num_lights;
 	vk_light_entity_t lights[256];
@@ -137,6 +144,10 @@ typedef struct {
 #define MAX_EXCLUDED_SMOOTHING_SURFACES_PAIRS 32
 		int excluded[MAX_EXCLUDED_SMOOTHING_SURFACES_PAIRS * 2];
 		int excluded_count;
+
+#define MAX_INCLUDED_SMOOTHING_GROUPS 32
+		int groups_count;
+		xvk_smoothing_group_t groups[MAX_INCLUDED_SMOOTHING_GROUPS];
 	} smoothing;
 } xvk_map_entities_t;
 


### PR DESCRIPTION
Smooth normals between selected brush surfaces if the angle between them is small enough.

- [x] Per-vertex-per-surface smoothing functionality (differs from qrad, which is per-edge; this gives artifacts as (supposedly) we have higher than lightmap lighting resolution)
- [x] Automatically select surfaces with less than X degrees between normals.
- [x] Make this X threshold adjustable from <map>.bsp.patch
- [ ] ~~Try not joining coplanar surfaces~~ -- doesn't seem to be affecting anything.
- [ ] ~~Think about linking surfaces more. Should we link distant surfaces w/o direct edges to this one?~~ -- it seems that we should be fine for now. Per-surface+vertex vs per-edge smoothing has no clear winner, just different tradeoffs.
- [ ] ~~Scale normals according to surfaces areas, so larger surfaces have more weight (experimental; may improve some artifacts)~~ -- also, non trivial to compute, and may not affect things too much.
- [x] Patch: add explicit smoothing or no-smoothing for given surfaces.

Fixes #139, supersedes #348