### PR TITLE
vk: do not draw into empty swapchain

### DIFF
--- a/ref/vk/vk_overlay.c
+++ b/ref/vk/vk_overlay.c
@@ -254,7 +254,7 @@ void R_VkOverlay_Shutdown( void ) {
 	vkDestroyPipelineLayout(vk_core.device, g2d.pipeline_layout, NULL);
 }
 
-void R_VkOverlay_DrawAndFlip( VkCommandBuffer cmdbuf ) {
+static void drawOverlay( VkCommandBuffer cmdbuf ) {
 	DEBUG_BEGIN(cmdbuf, "2d overlay");
 
 	{
@@ -275,6 +275,11 @@ void R_VkOverlay_DrawAndFlip( VkCommandBuffer cmdbuf ) {
 	}
 
 	DEBUG_END(cmdbuf);
+}
+
+void R_VkOverlay_DrawAndFlip( VkCommandBuffer cmdbuf, qboolean draw ) {
+	if (draw)
+		drawOverlay(cmdbuf);
 
 	clearAccumulated();
 }

--- a/ref/vk/vk_overlay.h
+++ b/ref/vk/vk_overlay.h
@@ -11,4 +11,5 @@ void CL_FillRGBABlend( float x, float y, float w, float h, int r, int g, int b, 
 
 qboolean R_VkOverlay_Init( void );
 void R_VkOverlay_Shutdown( void );
-void R_VkOverlay_DrawAndFlip( VkCommandBuffer cmdbuf );
+
+void R_VkOverlay_DrawAndFlip( VkCommandBuffer cmdbuf, qboolean draw );

--- a/ref/vk/vk_render.c
+++ b/ref/vk/vk_render.c
@@ -525,8 +525,11 @@ void VK_Render_FIXME_Barrier( VkCommandBuffer cmdbuf ) {
 	}
 }
 
-void VK_RenderEnd( VkCommandBuffer cmdbuf )
+void VK_RenderEnd( VkCommandBuffer cmdbuf, qboolean draw )
 {
+	if (!draw)
+		return;
+
 	// TODO we can sort collected draw commands for more efficient and correct rendering
 	// that requires adding info about distance to camera for correct order-dependent blending
 

--- a/ref/vk/vk_render.h
+++ b/ref/vk/vk_render.h
@@ -169,7 +169,7 @@ void VK_RenderDebugLabelBegin( const char *label );
 void VK_RenderDebugLabelEnd( void );
 
 void VK_RenderBegin( qboolean ray_tracing );
-void VK_RenderEnd( VkCommandBuffer cmdbuf );
+void VK_RenderEnd( VkCommandBuffer cmdbuf, qboolean draw );
 struct vk_combuf_s;
 void VK_RenderEndRTX( struct vk_combuf_s* combuf, VkImageView img_dst_view, VkImage img_dst, uint32_t w, uint32_t h );
 

--- a/ref/vk/vk_rtx.c
+++ b/ref/vk/vk_rtx.c
@@ -268,9 +268,6 @@ static void performTracing( vk_combuf_t *combuf, const perform_tracing_args_t* a
 
 	DEBUG_BEGIN(cmdbuf, "yay tracing");
 
-	// Feed tlas with dynamic data
-	RT_DynamicModelProcessFrame();
-
 	// TODO move this to "TLAS producer"
 	g_rtx.res[ExternalResource_tlas].resource = RT_VkAccelPrepareTlas(combuf);
 
@@ -541,6 +538,13 @@ void VK_RayFrameEnd(const vk_ray_frame_render_args_t* args)
 	}
 
 	ASSERT(g_rtx.mainpipe_out);
+
+	// Feed tlas with dynamic data
+	RT_DynamicModelProcessFrame();
+
+	// Do not draw when we have no swapchain
+	if (args->dst.image_view == VK_NULL_HANDLE)
+		return;
 
 	if (g_ray_model_state.frame.instances_count == 0) {
 		const r_vkimage_blit_args blit_args = {


### PR DESCRIPTION
On Windows we're seeing a max size = 0x0 swapchains. Those cannot be created or used. Make sure that we're not, and we're not trying to draw anything when there's no swapchain available.

Unfortunately we still have to call some rendering functions (without actually rendering anything) to make sure that various invariants hold.

fixes #463