### PR TITLE
vk: studio: do not ignore parent bones when detecting static submodels

### DIFF
--- a/ref/vk/vk_studio_model.h
+++ b/ref/vk/vk_studio_model.h
@@ -30,6 +30,7 @@ typedef struct r_studio_submodel_render_s {
 typedef struct r_studio_submodel_info_s {
 	const mstudiomodel_t *submodel_key;
 	qboolean is_dynamic;
+	//qboolean has_bonecontroller;
 
 	// TODO int verts_count; for prev_verts
 


### PR DESCRIPTION
python/357 has bullets submodels which are animated using parent bones. Their direct bones are static, and thus the entire submodel was picked up as static.

Now when computing bone transform for particular sequence/anim frame also merge it with parent transform. Bones are laid out sequentially in their "dependency order" so using a direct parent is fine, as it also contains its parent transforms.

Fixes: #554