### PR TITLE
vk: profiler: fix source locations for scopes (#542)

### DIFF
--- a/ref/vk/profiler.h
+++ b/ref/vk/profiler.h
@@ -4,8 +4,6 @@
 #include <assert.h>
 #include <string.h>
 
-#include "crtlib.h" // Q_strlen
-
 // Note: this module initializes itself on the first scope initialization.
 // I.e. it is invalid to call any of the functions before the first of aprof_scope_init/APROF_SCOPE_INIT/APROF_SCOPE_DECLARE_BEGIN is called.
 // TODO: explicit initialization function

--- a/ref/vk/profiler.h
+++ b/ref/vk/profiler.h
@@ -4,16 +4,20 @@
 #include <assert.h>
 #include <string.h>
 
+#include "crtlib.h" // Q_strlen
+
 // Note: this module initializes itself on the first scope initialization.
 // I.e. it is invalid to call any of the functions before the first of aprof_scope_init/APROF_SCOPE_INIT/APROF_SCOPE_DECLARE_BEGIN is called.
 // TODO: explicit initialization function
+
+#define APROF_FILENAME(filepath) aprof_get_filename_from_filepath( filepath, Q_strlen( filepath ) )
 
 #define APROF_SCOPE_DECLARE(scope) \
 	static aprof_scope_id_t _aprof_scope_id_##scope = -1
 
 // scope_name is expected to be static and alive for the entire duration of the program
 #define APROF_SCOPE_INIT_EX(scope, scope_name, flags) \
-	_aprof_scope_id_##scope = aprof_scope_init(scope_name, flags, __FILE__, __LINE__)
+	_aprof_scope_id_##scope = aprof_scope_init(scope_name, flags, APROF_FILENAME( __FILE__ ), __LINE__)
 
 #define APROF_SCOPE_INIT(scope, scope_name) APROF_SCOPE_INIT_EX(scope, scope_name, 0)
 
@@ -23,7 +27,7 @@
 #define APROF_SCOPE_DECLARE_BEGIN_EX(scope, scope_name, flags) \
 	static aprof_scope_id_t _aprof_scope_id_##scope = -1; \
 	if (_aprof_scope_id_##scope == -1) { \
-		_aprof_scope_id_##scope = aprof_scope_init(scope_name, flags, __FILE__, __LINE__); \
+		_aprof_scope_id_##scope = aprof_scope_init(scope_name, flags, APROF_FILENAME( __FILE__ ), __LINE__); \
 	} \
 	aprof_scope_event(_aprof_scope_id_##scope, 1)
 
@@ -41,8 +45,14 @@
 
 typedef int aprof_scope_id_t;
 
+// Returns pointer to filename in filepath string.
+// Ideally, this function should be static and visible only inside file scope,
+// but then the `APROF_FILENAME` macro would not work.
+// Also, maybe this function should be inside filesystem or something like that.
+const char *aprof_get_filename_from_filepath( const char *filepath, size_t filepath_length );
+
 // scope_name should be static const, and not on stack
-aprof_scope_id_t aprof_scope_init(const char *scope_name, uint32_t flags, const char *source_file, int source_line);
+aprof_scope_id_t aprof_scope_init(const char *scope_name, uint32_t flags, const char *source_filename, int source_line);
 void aprof_scope_event(aprof_scope_id_t, int begin);
 // Returns event index for previous frame
 uint32_t aprof_scope_frame( void );
@@ -67,7 +77,7 @@ enum {
 typedef struct {
 	const char *name;
 	uint32_t flags;
-	const char *source_file;
+	const char *source_filename;
 	int source_line;
 } aprof_scope_t;
 
@@ -147,7 +157,28 @@ uint64_t aprof_time_platform_to_ns( uint64_t platform_time ) {
 
 aprof_state_t g_aprof = {0};
 
-aprof_scope_id_t aprof_scope_init(const char *scope_name, uint32_t flags, const char *source_file, int source_line) {
+// Returns pointer to filename in filepath string.
+// Examples:
+// on Windows: C:/Users/User/xash3d-fwgs/ref/vk/vk_rtx.c  ->  vk_rtx.c
+// on Linux:   /home/user/xash3d-fwgs/ref/vk/vk_rtx.c     ->  vk.rtx.c (imaginary example, not tested)
+const char *aprof_get_filename_from_filepath( const char *filepath, size_t filepath_length ) {
+	if ( !filepath_length )
+		filepath_length = Q_strlen( filepath );
+
+	int cursor = filepath_length - 1;
+	while ( cursor > 0 ) {
+		char c = filepath[cursor];
+		if ( c == '/' || c == '\\' ) {
+			// Advance by 1 char to skip the folder delimiter symbol itself.
+			return &filepath[cursor + 1];
+		}
+		cursor -= 1;
+	}
+
+	return NULL;
+}
+
+aprof_scope_id_t aprof_scope_init(const char *scope_name, uint32_t flags, const char *source_filename, int source_line) {
 #if defined(_WIN32)
 	if (_aprof_frequency.QuadPart == 0)
 		QueryPerformanceFrequency(&_aprof_frequency);
@@ -161,7 +192,7 @@ aprof_scope_id_t aprof_scope_init(const char *scope_name, uint32_t flags, const 
 
 	g_aprof.scopes[g_aprof.num_scopes].name = scope_name;
 	g_aprof.scopes[g_aprof.num_scopes].flags = flags;
-	g_aprof.scopes[g_aprof.num_scopes].source_file = source_file;
+	g_aprof.scopes[g_aprof.num_scopes].source_filename = source_filename;
 	g_aprof.scopes[g_aprof.num_scopes].source_line = source_line;
 	return g_aprof.num_scopes++;
 }

--- a/ref/vk/r_speeds.c
+++ b/ref/vk/r_speeds.c
@@ -758,7 +758,7 @@ static void doPrintMetrics( void ) {
 		memset( line, '-', sizeof( line ) );
 	} else {
 		header_format = "  %s = %s  -->  (%s, %s)\n";
-		line_format   = "";
+		line_format   = NULL;
 		row_format    = "  ^2%s^7 = ^3%s^7  -->  (^5%s^7, ^6%s:%d^7)\n";
 	}
 
@@ -766,7 +766,7 @@ static void doPrintMetrics( void ) {
 	g_speeds.frame.metrics_print_mode = kSpeedsMprintNone;
 
 	gEngine.Con_Printf( header_format, "module.metric_name", "value", "variable", "registration_location" );
-	gEngine.Con_Printf( line_format, line, line, line, line );
+	if ( line_format )  gEngine.Con_Printf( line_format, line, line, line, line );
 	for ( int i = 0; i < g_speeds.metrics_count; ++i ) {
 		const r_speeds_metric_t *metric = g_speeds.metrics + i;
 
@@ -777,7 +777,7 @@ static void doPrintMetrics( void ) {
 		metricTypeSnprintf( value_with_unit, sizeof( value_with_unit ), *metric->p_value, metric->type );
 		gEngine.Con_Printf( row_format, metric->name, value_with_unit, metric->var_name, get_filename_from_filepath( metric->src_file ), metric->src_line );
 	}
-	gEngine.Con_Printf( line_format, line, line, line, line );
+	if ( line_format )  gEngine.Con_Printf( line_format, line, line, line, line );
 	gEngine.Con_Printf( header_format, "module.metric_name", "value", "variable", "registration_location" );
 }
 

--- a/ref/vk/r_speeds.c
+++ b/ref/vk/r_speeds.c
@@ -759,6 +759,7 @@ static void doListMetrics( void ) {
 		gEngine.Con_Printf( row_format, metric->name, value_with_unit, metric->var_name, metric->src_file, metric->src_line );
 	}
 	gEngine.Con_Printf( line_format, line, line, line, line );
+	gEngine.Con_Printf( header_format, "module.metric_name", "value", "variable", "registration_location" );
 }
 
 static void graphCmd( void ) {

--- a/ref/vk/r_speeds.c
+++ b/ref/vk/r_speeds.c
@@ -717,22 +717,17 @@ static const char *getMetricTypeName(r_speeds_metric_type_t type) {
 // on Windows: C:\Users\User\xash3d-fwgs\ref\vk\vk_rtx.c  ->  vk_rtx.c
 // on Linux:   /home/user/xash3d-fwgs/ref/vk/vk_rtx.c     ->  vk.rtx.c (imaginary example, not tested)
 static const char *get_filename_from_filepath( const char *filepath ) {
-	size_t length = Q_strlen( filepath );
-	int cursor = length - 1;
+	int cursor = Q_strlen( filepath ) - 1;
 	while ( cursor > 0 ) {
 		char c = filepath[cursor];
 		if ( c == '/' || c == '\\' ) {
-			// Advance by 1 char to skip the folder delimiter symbol itself, but
-			// make sure that we are not exceeding the length.
-			if ( cursor < length )
-				cursor += 1;
-
-			return &filepath[cursor];
+			// Advance by 1 char to skip the folder delimiter symbol itself.
+			return &filepath[cursor + 1];
 		}
 		cursor -= 1;
 	}
 
-	return NULL;
+	return filepath;
 }
 
 // Actually does the job of `r_speeds_mlist` and `r_speeds_mtable` commands.
@@ -755,11 +750,16 @@ static void doPrintMetrics( void ) {
 		header_format = "  | %-38s | %-10s | %-40s | %21s\n";
 		line_format   = "  | %.38s | %.10s | %.40s | %.21s\n";
 		row_format    = "  | ^2%-38s^7 | ^3%-10s^7 | ^5%-40s^7 | ^6%s:%d^7\n";
-		memset( line, '-', sizeof( line ) );
+
+		size_t line_size = sizeof ( line );
+		memset( line, '-', line_size - 1 );
+		line[line_size - 1] = '\0';
 	} else {
 		header_format = "  %s = %s  -->  (%s, %s)\n";
 		line_format   = NULL;
 		row_format    = "  ^2%s^7 = ^3%s^7  -->  (^5%s^7, ^6%s:%d^7)\n";
+
+		line[0] = '\0';
 	}
 
 	// Reset mode to print only this frame.

--- a/ref/vk/r_speeds.c
+++ b/ref/vk/r_speeds.c
@@ -745,8 +745,6 @@ static void doPrintMetrics( void ) {
 		// Note:
 		// This table alignment method relies on monospace font
 		// and will have its alignment completly broken without one.
-		// That is why there is now cvar called `r_speeds_metrics_as_table`,
-		// which can toggle this printing method on/off.
 		header_format = "  | %-38s | %-10s | %-40s | %21s\n";
 		line_format   = "  | %.38s | %.10s | %.40s | %.21s\n";
 		row_format    = "  | ^2%-38s^7 | ^3%-10s^7 | ^5%-40s^7 | ^6%s:%d^7\n";

--- a/ref/vk/r_speeds.c
+++ b/ref/vk/r_speeds.c
@@ -215,7 +215,15 @@ static void drawCPUProfilerScopes(int draw, const aprof_event_t *events, uint64_
 					const uint64_t delta_ns = timestamp_ns - stack[depth].begin_ns;
 
 					if (!g_speeds.frame.scopes[scope_id].initialized) {
-						R_SpeedsRegisterMetric(&g_speeds.frame.scopes[scope_id].time_us, "scope", scope->name, kSpeedsMetricMicroseconds, /*reset*/ true, scope->name, scope->source_file, scope->source_line);
+						R_SpeedsRegisterMetric(
+							/* p_value  */ &g_speeds.frame.scopes[scope_id].time_us, 
+							/* module   */ "scope", 
+							/* name     */ scope->name, 
+							/* type     */ kSpeedsMetricMicroseconds, 
+							/* reset    */ true, 
+							/* var_name */ scope->name, 
+							/* file     */ scope->source_filename, 
+							/* line     */ scope->source_line);
 
 						g_speeds.frame.scopes[scope_id].initialized = 1;
 					}
@@ -429,7 +437,16 @@ static void drawGPUProfilerScopes(qboolean draw, int y, uint64_t frame_begin_tim
 			const char *name = gpurofl->scopes[scope_index].name;
 
 			if (!g_speeds.frame.gpu_scopes[scope_index].initialized) {
-				R_SpeedsRegisterMetric(&g_speeds.frame.gpu_scopes[scope_index].time_us, "gpuscope", name, kSpeedsMetricMicroseconds, /*reset*/ true, name, __FILE__, __LINE__);
+				R_SpeedsRegisterMetric(
+					/* p_value  */ &g_speeds.frame.gpu_scopes[scope_index].time_us, 
+					/* module   */ "gpuscope", 
+					/* name     */ name, 
+					/* type     */ kSpeedsMetricMicroseconds, 
+					/* reset    */ true, 
+					/* var_name */ name, 
+					/* file     */ APROF_FILENAME( __FILE__ ), 
+					/* line     */ __LINE__);
+
 				g_speeds.frame.gpu_scopes[scope_index].initialized = 1;
 			}
 

--- a/ref/vk/r_speeds.c
+++ b/ref/vk/r_speeds.c
@@ -738,16 +738,15 @@ static const char *get_filename_from_filepath( const char *filepath ) {
 // Actually does the job of `r_speeds_mlist` and `r_speeds_mtable` commands.
 // We can't just directly call this function from little command handler ones, because
 // all the metrics calculations happen inside `R_SpeedsDisplayMore` function.
-static void doPrintMetrics( r_speeds_mprint_mode_t *print_mode, const char *print_filter ) {
-	r_speeds_mprint_mode_t mode = *print_mode;
-	if ( mode == kSpeedsMprintNone )
+static void doPrintMetrics( void ) {
+	if ( g_speeds.frame.metrics_print_mode == kSpeedsMprintNone )
 		return;
 
 	const char *header_format = NULL;
 	const char *line_format = NULL;
 	const char *row_format = NULL;
 	char line[64];
-	if ( mode == kSpeedsMprintTable ) {
+	if ( g_speeds.frame.metrics_print_mode == kSpeedsMprintTable ) {
 		// Note:
 		// This table alignment method relies on monospace font
 		// and will have its alignment completly broken without one.
@@ -764,14 +763,14 @@ static void doPrintMetrics( r_speeds_mprint_mode_t *print_mode, const char *prin
 	}
 
 	// Reset mode to print only this frame.
-	*print_mode = kSpeedsMprintNone;
+	g_speeds.frame.metrics_print_mode = kSpeedsMprintNone;
 
 	gEngine.Con_Printf( header_format, "module.metric_name", "value", "variable", "registration_location" );
 	gEngine.Con_Printf( line_format, line, line, line, line );
 	for ( int i = 0; i < g_speeds.metrics_count; ++i ) {
 		const r_speeds_metric_t *metric = g_speeds.metrics + i;
 
-		if ( print_filter[0] && !Q_strstr( metric->name, print_filter ) )
+		if ( g_speeds.frame.metrics_print_filter[0] && !Q_strstr( metric->name, g_speeds.frame.metrics_print_filter ) )
 			continue;
 
 		char value_with_unit[16];
@@ -783,7 +782,7 @@ static void doPrintMetrics( r_speeds_mprint_mode_t *print_mode, const char *prin
 }
 
 // Handles optional filter argument for `r_speeds_mlist` and `r_speeds_mtable` commands.
-static void handlePrintFilterArg() {
+static void handlePrintFilterArg( void ) {
 	if ( gEngine.Cmd_Argc() > 1 ) {
 		Q_strncpy( g_speeds.frame.metrics_print_filter, gEngine.Cmd_Argv( 1 ), sizeof( g_speeds.frame.metrics_print_filter ) );
 	} else {
@@ -994,7 +993,7 @@ void R_SpeedsDisplayMore(uint32_t prev_frame_index, const struct vk_combuf_scope
 
 	processGraphCvar();
 
-	doPrintMetrics( &g_speeds.frame.metrics_print_mode, g_speeds.frame.metrics_print_filter );
+	doPrintMetrics();
 
 	resetMetrics();
 

--- a/ref/vk/r_speeds.c
+++ b/ref/vk/r_speeds.c
@@ -214,7 +214,7 @@ static void drawCPUProfilerScopes(int draw, const aprof_event_t *events, uint64_
 					const uint64_t delta_ns = timestamp_ns - stack[depth].begin_ns;
 
 					if (!g_speeds.frame.scopes[scope_id].initialized) {
-						R_SpeedsRegisterMetric(&g_speeds.frame.scopes[scope_id].time_us, "scope", scope->name, kSpeedsMetricMicroseconds, /*reset*/ true, scope->name, __FILE__, __LINE__);
+						R_SpeedsRegisterMetric(&g_speeds.frame.scopes[scope_id].time_us, "scope", scope->name, kSpeedsMetricMicroseconds, /*reset*/ true, scope->name, scope->source_file, scope->source_line);
 
 						g_speeds.frame.scopes[scope_id].initialized = 1;
 					}

--- a/ref/vk/r_speeds.h
+++ b/ref/vk/r_speeds.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "xash3d_types.h"
-#include "profiler.h" // APROF_FILENAME
 #include <stdint.h>
 
 void R_SpeedsInit( void );
@@ -23,9 +22,9 @@ void R_SpeedsRegisterMetric(int* p_value, const char *module, const char *name, 
 // A counter is a value accumulated during a single frame, and reset to zero between frames.
 // Examples: drawn models count, scope times, etc.
 #define R_SPEEDS_COUNTER(var, name, type) \
-	R_SpeedsRegisterMetric(&(var), MODULE_NAME, name, type, /*reset*/ true, #var, APROF_FILENAME( __FILE__ ), __LINE__)
+	R_SpeedsRegisterMetric(&(var), MODULE_NAME, name, type, /*reset*/ true, #var, __FILE__, __LINE__)
 
 // A metric is computed and preserved across frame boundaries.
 // Examples: total allocated memory, cache sizes, etc.
 #define R_SPEEDS_METRIC(var, name, type) \
-	R_SpeedsRegisterMetric(&(var), MODULE_NAME, name, type, /*reset*/ false, #var, APROF_FILENAME( __FILE__ ), __LINE__)
+	R_SpeedsRegisterMetric(&(var), MODULE_NAME, name, type, /*reset*/ false, #var, __FILE__, __LINE__)

--- a/ref/vk/r_speeds.h
+++ b/ref/vk/r_speeds.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "xash3d_types.h"
+#include "profiler.h" // APROF_FILENAME
 #include <stdint.h>
 
 void R_SpeedsInit( void );
@@ -22,9 +23,9 @@ void R_SpeedsRegisterMetric(int* p_value, const char *module, const char *name, 
 // A counter is a value accumulated during a single frame, and reset to zero between frames.
 // Examples: drawn models count, scope times, etc.
 #define R_SPEEDS_COUNTER(var, name, type) \
-	R_SpeedsRegisterMetric(&(var), MODULE_NAME, name, type, /*reset*/ true, #var, __FILE__, __LINE__)
+	R_SpeedsRegisterMetric(&(var), MODULE_NAME, name, type, /*reset*/ true, #var, APROF_FILENAME( __FILE__ ), __LINE__)
 
 // A metric is computed and preserved across frame boundaries.
 // Examples: total allocated memory, cache sizes, etc.
 #define R_SPEEDS_METRIC(var, name, type) \
-	R_SpeedsRegisterMetric(&(var), MODULE_NAME, name, type, /*reset*/ false, #var, __FILE__, __LINE__)
+	R_SpeedsRegisterMetric(&(var), MODULE_NAME, name, type, /*reset*/ false, #var, APROF_FILENAME( __FILE__ ), __LINE__)


### PR DESCRIPTION
Fix source locations for scopes in `r_speeds_list_metrics` as described in Issue #542. 
Also slightly simplify metrics list print formatting and add an option to print it as a table. It can be turned on/off via cvar `r_speeds_metrics_as_table`. 
This does not look very good in HL itself because it uses non-monospace font by default in console, but it looks much cleaner and readable in console and log file output.