### PR TITLE
vk: fix roughness on studio model chrome textures

### DIFF
--- a/ref/vk/vk_materials.c
+++ b/ref/vk/vk_materials.c
@@ -23,8 +23,6 @@ static r_vk_material_t k_default_material = {
 	.roughness = 1.f,
 	.normal_scale = 1.f,
 	.base_color = { 1.f, 1.f, 1.f, 1.f },
-
-	.set = false,
 };
 
 /* TODO
@@ -462,6 +460,10 @@ void R_VkMaterialsLoadForModel( const struct model_s* mod ) {
 }
 
 r_vk_material_t R_VkMaterialGetForTexture( int tex_index ) {
+	return R_VkMaterialGetForTextureWithFlags( tex_index, kVkMaterialFlagNone );
+}
+
+r_vk_material_t R_VkMaterialGetForTextureWithFlags( int tex_index, uint32_t flags ) {
 	//DEBUG("Getting material for tex_id=%d", tex_index);
 	ASSERT(tex_index >= 0);
 	ASSERT(tex_index < MAX_TEXTURES);
@@ -488,6 +490,10 @@ r_vk_material_t R_VkMaterialGetForTexture( int tex_index ) {
 
 	r_vk_material_t ret = k_default_material;
 	ret.tex_base_color = tex_index;
+
+	if ( flags & kVkMaterialFlagChrome )
+		ret.roughness = tglob.grayTexture;
+
 	//DEBUG("Returning default material with tex_base_color=%d", tex_index);
 	return ret;
 }

--- a/ref/vk/vk_materials.h
+++ b/ref/vk/vk_materials.h
@@ -26,9 +26,6 @@ typedef struct r_vk_material_s {
 	float roughness;
 	float metalness;
 	float normal_scale;
-
-	// TODO this should be internal
-	qboolean set;
 } r_vk_material_t;
 
 typedef struct { int index; } r_vk_material_ref_t;
@@ -44,6 +41,13 @@ r_vk_material_ref_t R_VkMaterialGetForName( const char *name );
 r_vk_material_t R_VkMaterialGetForRef( r_vk_material_ref_t ref );
 
 r_vk_material_t R_VkMaterialGetForTexture( int tex_id );
-r_vk_material_t R_VkMaterialGetForTextureChrome( int tex_id );
+
+enum {
+	kVkMaterialFlagNone = 0,
+	// Studio model STUDIO_NF_CHROME
+	kVkMaterialFlagChrome = (1<<0),
+};
+
+r_vk_material_t R_VkMaterialGetForTextureWithFlags( int tex_id, uint32_t flags );
 
 qboolean R_VkMaterialGetEx( int tex_id, int rendermode, r_vk_material_t *out_material );

--- a/ref/vk/vk_studio.c
+++ b/ref/vk/vk_studio.c
@@ -1770,7 +1770,7 @@ static void buildSubmodelMeshGeometry( build_submodel_mesh_t args ) {
 	ASSERT(vertex_offset == num_vertices);
 
 	*args.out_geometry = (vk_render_geometry_t){
-		.material = R_VkMaterialGetForTexture(args.texture),
+		.material = R_VkMaterialGetForTextureWithFlags(args.texture, FBitSet( args.face_flags, STUDIO_NF_CHROME ) ? kVkMaterialFlagChrome : kVkMaterialFlagNone),
 		.ye_olde_texture = args.texture,
 
 		.vertex_offset = args.vertices_offset,
@@ -1781,11 +1781,6 @@ static void buildSubmodelMeshGeometry( build_submodel_mesh_t args ) {
 
 		.emissive = {0, 0, 0},
 	};
-
-	if (!args.out_geometry->material.set && FBitSet( args.face_flags, STUDIO_NF_CHROME )) {
-		// TODO configurable
-		args.out_geometry->material.roughness = tglob.grayTexture;
-	}
 
 	*args.out_vertices_count += num_vertices;
 	*args.out_indices_count += num_indices;


### PR DESCRIPTION
With deprecation of `set` flag, roughness was always replaced on studio model chome textures.