### PR TITLE
vk: add a mechanism for exclusion of single surfaces from smoothing

### DIFF
--- a/ref/vk/TODO.md
+++ b/ref/vk/TODO.md
@@ -5,7 +5,9 @@
     - [x] single return/goto cleanup
     - [-] pass args via structs? -> not necessary
     - [-] collapse texture uploading into a single function -> not necessary, they are different enough
-- [ ] merge materials PR
+- [x] merge materials PR
+- [x] studio gibs translucency
+- [x] smoothing exclusion
 
 # 2023-10-30 E321
 - [x] missing skybox

--- a/ref/vk/data/valve/luchiki/maps/c1a1b.patch
+++ b/ref/vk/data/valve/luchiki/maps/c1a1b.patch
@@ -89,3 +89,7 @@ _xvk_smooth_entire_model "1"
 {
 //"_xvk_smoothing_threshold" "44" //workaround
 }
+
+{
+_xvk_smoothing_excluded "2120 2117 2118 1269 1267 2791 2792 2793"
+}

--- a/ref/vk/shaders/denoiser.comp
+++ b/ref/vk/shaders/denoiser.comp
@@ -241,8 +241,10 @@ void main() {
 	//imageStore(out_dest, pix, vec4(.5 + geometry_normal * .5, 0.)); return;
 	//const vec4 mat_rmxx = imageLoad(material_rmxx, pix);
 	//imageStore(out_dest, pix, vec4((.5 + shading_normal * .5)*.8 + .2 * mat_rmxx.a , 0.)); return;
+	//imageStore(out_dest, pix, vec4(.5 + shading_normal * .5, 0.)); return;
 
-	vec3 normal = pix.x < res.x / 2 ? shading_normal : geometry_normal;
+	//vec3 normal = pix.x < res.x / 2 ? shading_normal : geometry_normal;
+	vec3 normal = shading_normal;// : geometry_normal;
 	imageStore(out_dest, pix, vec4(.5 + normal * .5, 0.)); return;
 #endif
 

--- a/ref/vk/vk_mapents.h
+++ b/ref/vk/vk_mapents.h
@@ -37,6 +37,7 @@
 	X(25, string, _xvk_map_material, String) \
 	X(26, int, rendermode, Int) \
 	X(27, int, _xvk_smooth_entire_model, Int) \
+	X(28, int_array_t, _xvk_smoothing_excluded, IntArray) \
 
 /* NOTE: not used
 	X(23, int, renderamt, Int) \
@@ -162,15 +163,20 @@ typedef struct {
 		float threshold;
 
 #define MAX_EXCLUDED_SMOOTHING_SURFACES_PAIRS 32
-		int excluded[MAX_EXCLUDED_SMOOTHING_SURFACES_PAIRS * 2];
-		int excluded_count;
+		int excluded_pairs[MAX_EXCLUDED_SMOOTHING_SURFACES_PAIRS * 2];
+		int excluded_pairs_count;
 
 #define MAX_INCLUDED_SMOOTHING_GROUPS 32
 		int groups_count;
 		xvk_smoothing_group_t groups[MAX_INCLUDED_SMOOTHING_GROUPS];
+
+#define MAX_EXCLUDED_SMOOTHING_SURFACES 256
+		int excluded_count;
+		int excluded[MAX_EXCLUDED_SMOOTHING_SURFACES];
 	} smoothing;
 } xvk_map_entities_t;
 
+// TODO expose a bunch of things here as funtions, not as internal structures
 extern xvk_map_entities_t g_map_entities;
 
 enum { NoEnvironmentLights = -1, MoreThanOneEnvironmentLight = -2 };


### PR DESCRIPTION
Uses `_xvk_smoothing_excluded` field.

Surfaces can still be smoothed with a limited list of neightbours explicitly by being included in a smoothing group.

Fixes #619