### PR TITLE
vk: fix weird lines on suit studio model

### DIFF
--- a/ref/vk/shaders/denoiser.comp
+++ b/ref/vk/shaders/denoiser.comp
@@ -262,7 +262,8 @@ void main() {
 	{
 		// TODO: need to extract reprojecting from this shader because reprojected stuff need svgf denoising pass after it
 		const vec3 origin = (ubo.ubo.inv_view * vec4(0., 0., 0., 1.)).xyz;
-		const float depth = length(origin - imageLoad(position_t, pix).xyz);
+		const vec3 position = imageLoad(position_t, pix).xyz;
+		const float depth = length(origin - position);
 		const vec3 prev_position = imageLoad(geometry_prev_position, pix).rgb;
 		const vec4 clip_space = inverse(ubo.ubo.prev_inv_proj) * vec4((inverse(ubo.ubo.prev_inv_view) * vec4(prev_position, 1.)).xyz, 1.);
 		const vec2 reproj_uv = clip_space.xy / clip_space.w;
@@ -305,6 +306,8 @@ void main() {
 		colour = diffuse + specular;
 
 		//imageStore(out_dest, pix, vec4(LINEARtoSRGB(diffuse), 0.)); return;
+		//imageStore(out_dest, pix, vec4(fract(abs(position - prev_position)), 0./*unused*/)); return;
+		//imageStore(out_dest, pix, vec4(fract(abs(prev_position)), 0./*unused*/)); return;
 	}
 
 	const vec4 base_color_a = SRGBtoLINEAR(imageLoad(base_color_a, pix));

--- a/ref/vk/vk_studio.c
+++ b/ref/vk/vk_studio.c
@@ -2117,18 +2117,18 @@ static qboolean studioSubmodelRenderInit(r_studio_submodel_render_t *render_subm
 	vk_render_geometry_t *const geometries = Mem_Malloc(vk_core.pool, submodel->nummesh * sizeof(*geometries));
 	ASSERT(geometries);
 
-	const size_t verts_size = sizeof(vec3_t) * submodel->numverts;
-	render_submodel->prev_verts = Mem_Malloc(vk_core.pool, verts_size);
-	memcpy(render_submodel->prev_verts, g_studio.verts, verts_size);
-
 	buildStudioSubmodelGeometry((build_submodel_geometry_t){
-		//.submodel = submodel,
 		.geometry = &geometry,
 		.geometries = geometries,
 		.vertex_count = vertex_count,
 		.index_count = index_count,
-		.prev_verts = render_submodel->prev_verts,
+		.prev_verts = g_studio.verts,
 	});
+
+	// Store vertices computed by bulidStudioSubmodelGeometry as intial prev_verts
+	const size_t verts_size = sizeof(vec3_t) * submodel->numverts;
+	render_submodel->prev_verts = Mem_Malloc(vk_core.pool, verts_size);
+	memcpy(render_submodel->prev_verts, g_studio.verts, verts_size);
 
 	render_submodel->geometries = geometries;
 	render_submodel->geometries_count = submodel->nummesh;


### PR DESCRIPTION
It was using old pre-transform values for prev_verts, and that was confusing temporal denoiser.

We should bone-transform vertices first, and only then store them as prev_verts.

Fixes #585