### PR TITLE
vk: fix occasional inverted normal maps

### DIFF
--- a/ref/vk/TODO.md
+++ b/ref/vk/TODO.md
@@ -1,7 +1,8 @@
 # 2023-11-02 E323
 - [x] lol meta: read and sort issues
 - [x] merge from upstream
-- [ ] hevsuit glitches
+- [x] hevsuit glitches
+- [x] inverted normal map orientation
 - [ ] massage shaders: consolidate all bindings explicitly
 - [ ] skip sorting-by-texture when loading brush models (=> geometry count explosion; i.e. kusochki count will explode too)
 - [ ] kusochki-vs-materials

--- a/ref/vk/vk_descriptor.c
+++ b/ref/vk/vk_descriptor.c
@@ -173,7 +173,7 @@ void VK_DescriptorsCreate(vk_descriptors_t *desc)
 
 void VK_DescriptorsWrite(const vk_descriptors_t *desc, int set_slot)
 {
-	VkWriteDescriptorSet wds[16];
+	VkWriteDescriptorSet wds[32];
 	ASSERT(ARRAYSIZE(wds) >= desc->num_bindings);
 	for (int i = 0; i < desc->num_bindings; ++i){
 		const VkDescriptorSetLayoutBinding *binding = desc->bindings + i;


### PR DESCRIPTION
When texture coordinates are inverted, it makes tangent look into oppsite direction, which inverts TBN and therefore normal map.

Make sure the tangent points to a consistent direction.

Fixes #627