### PR TITLE
E328-E330: Improve backface culling

### DIFF
--- a/ref/vk/NOTES.md
+++ b/ref/vk/NOTES.md
@@ -713,3 +713,18 @@ VK:
 - no PLANE_Z check: sphere=1 side=1
 
 EXPLANATION: `!=PLANE_Z` is only culled for non-worldmodel entities. Worldmodel doesn't cull by != PLANE_Z.
+
+# 2023-11-10 #E328
+MORE WATER
+- There are 2 msurface_t for water surfaces, one for each "orientation": front and back
+- The "back" one usually has SURF_PLANEBACK flag, and can be culled as such
+- For most of water bodies completely removing the SURF_PLANEBACK surface solves the coplanar glitches
+    - However, that breaks the trad rederer: can no longer see the water surface from underwater
+    - Also breaks the water spehere in test_brush2: its surfaces are not oriented properly and uniformly "outwards" vs "inwards"
+    - No amount of flag SURF_UNDERWATER/SURF_PLANEBACK culling produces consistent results
+
+What can be done:
+1. Leave it as-is, with double sided surfaces and all that. To fix ray tracing:
+    - Make it cull back-sided polygons
+    - Ensure that any reflections and refractions are delta-far-away enough to not be caught between imprecise coplanar planes.
+2. Do the culling later: at glpoly stage. Do not emit glpolys that are oriented in the opposite direction from the surface producing them.

--- a/ref/vk/TODO.md
+++ b/ref/vk/TODO.md
@@ -1,3 +1,9 @@
+# 2023-11-13 E329
+- [-] culling -> need to cull everything except opaque and blend. Alpha-mask is culled.
+- [-] waters:
+     - [-] No water surface visible from underneath -- hidden by enabling culling
+     - [-] No coplanar issues visible? -- hidden by culling. Disabling culling makes glitches reappear
+
 # 2023-11-10 E328
 - [ ] woditschka
      - [-] potentially collinear planes vs ray tracing #264

--- a/ref/vk/TODO.md
+++ b/ref/vk/TODO.md
@@ -1,3 +1,15 @@
+# 2023-11-14 E330
+- [x] culling worldmodel waters
+     - [-] try simple flag culling (probably won't work)
+     - [-] try detecting glpoly normals -> consistent with SURF_PLANEBACK, doesn't help
+     - [x] SURF_UNDERWATER seems to get us a SINLE surface looking outwards
+- [x] investigate gl backface culling for transparent surfaces:
+    - [ ] glass -- seems to have 2nd face (brush backside)
+    - [x] water -- doesn't seem to have 2nd face
+        - [x] glpoly_t winding order is reversed when camera origin is opposite to (SURF_PLANEBACK-aware) surface normal
+- [x] discuss culling transparent surfaces strategies
+- [ ] discuss integration test strategies
+
 # 2023-11-13 E329
 - [-] culling -> need to cull everything except opaque and blend. Alpha-mask is culled.
 - [-] waters:

--- a/ref/vk/TODO.md
+++ b/ref/vk/TODO.md
@@ -1,10 +1,17 @@
+# 2023-11-10 E328
+- [ ] woditschka
+     - [-] potentially collinear planes vs ray tracing #264
+         - not super clear how exactly it works, and what it does. And how to cull things
+         - leaning towards making our own tesselator, as it might be universally usable for other things, e.g. detail mapping
+         - [ ] (A) try producing simple surfaces w/o tesselation, similar to regular brush surfaces
+         - [x] (C) print out all surfaces and polys to see where are they looking
+         - [-] (B) try filtering surfaces looking down
+
 # 2023-11-09 E327
 - [x] update animated textures is now super slow: some static map surfaces have alternate anims (e.g. light post on c2a5)
-- [ ] woditschka
+- [-] woditschka
      - [x] height not switching to negative underwater -- decided that we don't need it for now
      - [x] do not draw water sides when not requested.
-     - [ ] potentially collinear planes vs ray tracing #264
-
 
 # 2023-11-07 E326
 - [x] list supported arguments for `rt_debug_display_only` cvar

--- a/ref/vk/shaders/bounce.comp
+++ b/ref/vk/shaders/bounce.comp
@@ -52,7 +52,7 @@ void readNormals(ivec2 uv, out vec3 geometry_normal, out vec3 shading_normal) {
 bool getHit(vec3 origin, vec3 direction, inout RayPayloadPrimary payload) {
 	rayQueryEXT rq;
 	const uint flags = 0
-		//| gl_RayFlagsCullFrontFacingTrianglesEXT
+		| gl_RayFlagsCullFrontFacingTrianglesEXT
 		//| gl_RayFlagsOpaqueEXT
 		//| gl_RayFlagsTerminateOnFirstHitEXT
 		//| gl_RayFlagsSkipClosestHitShaderEXT

--- a/ref/vk/shaders/ray_primary.comp
+++ b/ref/vk/shaders/ray_primary.comp
@@ -69,7 +69,7 @@ void main() {
 
 	rayQueryEXT rq;
 	const uint flags = 0
-		//| gl_RayFlagsCullFrontFacingTrianglesEXT
+		| gl_RayFlagsCullFrontFacingTrianglesEXT
 		//| gl_RayFlagsOpaqueEXT
 		//| gl_RayFlagsTerminateOnFirstHitEXT
 		//| gl_RayFlagsSkipClosestHitShaderEXT

--- a/ref/vk/vk_brush.c
+++ b/ref/vk/vk_brush.c
@@ -419,9 +419,6 @@ static void fillWaterSurfaces( fill_water_surfaces_args_t args ) {
 		const int surf_index = args.wmodel->surfaces_indices[i];
 		const msurface_t *warp = args.surfaces + surf_index;
 
-		/* if( warp->plane->type != PLANE_Z && !FBitSet( ent->curstate.effects, EF_WATERSIDES )) */
-		/* 	continue; */
-
 		int vertices = 0, indices = 0;
 		brushComputeWaterPolys((compute_water_polys_t){
 			.prev_time = args.prev_time,

--- a/ref/vk/vk_ray_accel.c
+++ b/ref/vk/vk_ray_accel.c
@@ -275,7 +275,9 @@ vk_resource_t RT_VkAccelPrepareTlas(vk_combuf_t *combuf) {
 				case MATERIAL_MODE_OPAQUE:
 					inst[i].mask = GEOMETRY_BIT_OPAQUE;
 					inst[i].instanceShaderBindingTableRecordOffset = SHADER_OFFSET_HIT_REGULAR,
-					inst[i].flags = VK_GEOMETRY_INSTANCE_FORCE_OPAQUE_BIT_KHR;
+					// Force no-culling because there are cases where culling leads to leaking shadows, holes in reflections, etc
+					// CULL_DISABLE_BIT disables culling even if the gl_RayFlagsCullFrontFacingTrianglesEXT bit is set in shaders
+					inst[i].flags = VK_GEOMETRY_INSTANCE_FORCE_OPAQUE_BIT_KHR | VK_GEOMETRY_INSTANCE_TRIANGLE_FACING_CULL_DISABLE_BIT_KHR;
 					break;
 				case MATERIAL_MODE_OPAQUE_ALPHA_TEST:
 					inst[i].mask = GEOMETRY_BIT_ALPHA_TEST;
@@ -292,7 +294,8 @@ vk_resource_t RT_VkAccelPrepareTlas(vk_combuf_t *combuf) {
 				case MATERIAL_MODE_BLEND_GLOW:
 					inst[i].mask = GEOMETRY_BIT_BLEND;
 					inst[i].instanceShaderBindingTableRecordOffset = SHADER_OFFSET_HIT_ADDITIVE,
-					inst[i].flags = VK_GEOMETRY_INSTANCE_FORCE_NO_OPAQUE_BIT_KHR;
+					// Force no-culling because these should be visible from any angle
+					inst[i].flags = VK_GEOMETRY_INSTANCE_FORCE_NO_OPAQUE_BIT_KHR | VK_GEOMETRY_INSTANCE_TRIANGLE_FACING_CULL_DISABLE_BIT_KHR;
 					break;
 				default:
 					gEngine.Host_Error("Unexpected material mode %d\n", instance->material_mode);

--- a/ref/vk/vk_ray_accel.c
+++ b/ref/vk/vk_ray_accel.c
@@ -287,7 +287,8 @@ vk_resource_t RT_VkAccelPrepareTlas(vk_combuf_t *combuf) {
 				case MATERIAL_MODE_TRANSLUCENT:
 					inst[i].mask = GEOMETRY_BIT_REFRACTIVE;
 					inst[i].instanceShaderBindingTableRecordOffset = SHADER_OFFSET_HIT_REGULAR,
-					inst[i].flags = VK_GEOMETRY_INSTANCE_FORCE_OPAQUE_BIT_KHR;
+					// Disable culling for translucent surfaces: decide what side it is based on normal wrt ray directions
+					inst[i].flags = VK_GEOMETRY_INSTANCE_FORCE_OPAQUE_BIT_KHR | VK_GEOMETRY_INSTANCE_TRIANGLE_FACING_CULL_DISABLE_BIT_KHR;
 					break;
 				case MATERIAL_MODE_BLEND_ADD:
 				case MATERIAL_MODE_BLEND_MIX:


### PR DESCRIPTION
- [x] Turn on backface culling in RT shaders for everything.
- [x] Force-disable culling for everything except alpha blended geometries.
- [x] Only leave water surfaces that are directed towards "air", fixes #264 