### PR TITLE
Skybox improvements (E346-E347)

### DIFF
--- a/engine/common/imagelib/img_ktx2.c
+++ b/engine/common/imagelib/img_ktx2.c
@@ -65,6 +65,22 @@ static void Image_KTX2Format( uint32_t ktx2_format )
 	}
 }
 
+static const int g_remap_cube_layer[6] = {
+/* Face order
+ 0   1   2   3   4   5  -- index
+ft, bk, up, dn, rt, lf  -- xash
++x, -x, +y, -y, +z, -z  -- KTX2
+rt, lf, bk, ft, up, dn  -- ref_vk
+
+texture[face] = ktx2[map[face]], e.g.:
+texture[rt] = ktx2[+z = 4]
+texture[lf] = ktx2[-z = 5]
+texture[bk] = ktx2[-x = 1]
+...
+*/
+	4, 5, 1, 0, 2, 3
+};
+
 static qboolean Image_KTX2Parse( const ktx2_header_t *header, const byte *buffer, fs_offset_t filesize )
 {
 	ktx2_index_t index;
@@ -93,7 +109,7 @@ static qboolean Image_KTX2Parse( const ktx2_header_t *header, const byte *buffer
 		return false;
 	}
 
-	if( header->faceCount > 1 )
+	if( header->faceCount != 1 && header->faceCount != 6 )
 	{
 		Con_DPrintf( S_ERROR "%s: unsupported KTX2 faceCount %d\n", __FUNCTION__, header->faceCount );
 		return false;
@@ -128,10 +144,10 @@ static qboolean Image_KTX2Parse( const ktx2_header_t *header, const byte *buffer
 		ktx2_level_t level;
 		memcpy( &level, levels_begin + mip * sizeof( level ), sizeof( level ));
 
-		if( mip_size != level.byteLength )
+		if( mip_size * header->faceCount != level.byteLength )
 		{
-			Con_DPrintf( S_ERROR "%s: mip=%d size mismatch read=%d, but computed=%d\n",
-				__FUNCTION__, mip, (int)level.byteLength, mip_size );
+			Con_DPrintf( S_ERROR "%s: mip=%d size mismatch read=%d, but computed=%d(mip=%d * faces=%d)\n",
+				__FUNCTION__, mip, (int)level.byteLength, mip_size * header->faceCount, mip_size, header->faceCount );
 			return false;
 		}
 
@@ -139,8 +155,11 @@ static qboolean Image_KTX2Parse( const ktx2_header_t *header, const byte *buffer
 		max_offset = Q_max( max_offset, level.byteLength + level.byteOffset );
 	}
 
-	if( max_offset > filesize )
+	if( max_offset > filesize ) {
+		Con_DPrintf( S_ERROR "%s: size to read %d exceeds file size %d\n",
+			__FUNCTION__, (int)max_offset, (int)filesize );
 		return false;
+	}
 
 	image.size = total_size;
 	image.num_mips = header->levelCount;
@@ -148,12 +167,25 @@ static qboolean Image_KTX2Parse( const ktx2_header_t *header, const byte *buffer
 	image.rgba = Mem_Malloc( host.imagepool, image.size );
 	memcpy( image.rgba, buffer, image.size );
 
-	for( int mip = 0, cursor = 0; mip < header->levelCount; ++mip )
+	int cursors[6] = {0};
+	if ( header->faceCount == 6 ) {
+		image.flags |= IMAGE_CUBEMAP;
+
+		for ( int face = 0; face < header->faceCount; ++face )
+			cursors[face] = g_remap_cube_layer[face] * total_size / header->faceCount;
+	}
+
+	for( int mip = 0; mip < header->levelCount; ++mip )
 	{
 		ktx2_level_t level;
 		memcpy( &level, levels_begin + mip * sizeof( level ), sizeof( level ));
-		memcpy( image.rgba + cursor, buffer + level.byteOffset, level.byteLength );
-		cursor += level.byteLength;
+
+		const int face_size = level.byteLength / header->faceCount;
+		for ( int face = 0; face < header->faceCount; ++face )
+		{
+			memcpy( image.rgba + cursors[face], buffer + level.byteOffset + face * face_size, face_size );
+			cursors[face] += face_size;
+		}
 	}
 
 	return true;
@@ -179,7 +211,7 @@ qboolean Image_LoadKTX2( const char *name, const byte *buffer, fs_offset_t files
 	image.depth = Q_max( 1, header.pixelDepth );
 	image.num_mips = 1;
 
-	ClearBits( image.flags, IMAGE_HAS_COLOR | IMAGE_HAS_ALPHA | IMAGE_HAS_LUMA );
+	ClearBits( image.flags, IMAGE_HAS_COLOR | IMAGE_HAS_ALPHA | IMAGE_HAS_LUMA | IMAGE_CUBEMAP );
 
 	if( !Image_KTX2Parse( &header, buffer, filesize ))
 	{

--- a/engine/common/imagelib/img_ktx2.c
+++ b/engine/common/imagelib/img_ktx2.c
@@ -179,9 +179,11 @@ static qboolean Image_KTX2Parse( const ktx2_header_t *header, const byte *buffer
 		for( int mip = 0; mip < header->levelCount; ++mip )
 		{
 			ktx2_level_t level;
-			memcpy( &level, levels_begin + mip * sizeof( level ), sizeof( level ));
+			int face_size = 0;
 
-			const int face_size = level.byteLength / header->faceCount;
+			memcpy( &level, levels_begin + mip * sizeof( level ), sizeof( level ));
+			face_size = level.byteLength / header->faceCount;
+
 			for ( int face = 0; face < header->faceCount; ++face )
 			{
 				memcpy( image.rgba + cursors[face], buffer + level.byteOffset + face * face_size, face_size );

--- a/engine/common/imagelib/img_ktx2.c
+++ b/engine/common/imagelib/img_ktx2.c
@@ -167,24 +167,26 @@ static qboolean Image_KTX2Parse( const ktx2_header_t *header, const byte *buffer
 	image.rgba = Mem_Malloc( host.imagepool, image.size );
 	memcpy( image.rgba, buffer, image.size );
 
-	int cursors[6] = {0};
-	if ( header->faceCount == 6 ) {
-		image.flags |= IMAGE_CUBEMAP;
-
-		for ( int face = 0; face < header->faceCount; ++face )
-			cursors[face] = g_remap_cube_layer[face] * total_size / header->faceCount;
-	}
-
-	for( int mip = 0; mip < header->levelCount; ++mip )
 	{
-		ktx2_level_t level;
-		memcpy( &level, levels_begin + mip * sizeof( level ), sizeof( level ));
+		int cursors[6] = {0};
+		if ( header->faceCount == 6 ) {
+			image.flags |= IMAGE_CUBEMAP;
 
-		const int face_size = level.byteLength / header->faceCount;
-		for ( int face = 0; face < header->faceCount; ++face )
+			for ( int face = 0; face < header->faceCount; ++face )
+				cursors[face] = g_remap_cube_layer[face] * total_size / header->faceCount;
+		}
+
+		for( int mip = 0; mip < header->levelCount; ++mip )
 		{
-			memcpy( image.rgba + cursors[face], buffer + level.byteOffset + face * face_size, face_size );
-			cursors[face] += face_size;
+			ktx2_level_t level;
+			memcpy( &level, levels_begin + mip * sizeof( level ), sizeof( level ));
+
+			const int face_size = level.byteLength / header->faceCount;
+			for ( int face = 0; face < header->faceCount; ++face )
+			{
+				memcpy( image.rgba + cursors[face], buffer + level.byteOffset + face * face_size, face_size );
+				cursors[face] += face_size;
+			}
 		}
 	}
 

--- a/engine/common/imagelib/img_main.c
+++ b/engine/common/imagelib/img_main.c
@@ -178,7 +178,9 @@ static qboolean FS_AddSideToPack( int adjust_flags )
 	}
 
 	// keep constant size, render.dll expecting it
-	image.size = image.source_width * image.source_height * 4;
+	// NOTE: This is super incorrect for compressed images.
+	// No idea why it was needed
+	// image.size = image.source_width * image.source_height * 4;
 
 	// mixing dds format with any existing ?
 	if( image.type != image.source_type )

--- a/engine/common/imagelib/img_utils.c
+++ b/engine/common/imagelib/img_utils.c
@@ -95,6 +95,7 @@ static const loadpixformat_t load_null[] =
 
 static const loadpixformat_t load_game[] =
 {
+{ "%s%s.%s", "ktx2", Image_LoadKTX2, IL_HINT_NO },	// ktx2 for world and studio models
 { "%s%s.%s", "dds", Image_LoadDDS, IL_HINT_NO },	// dds for world and studio models
 { "%s%s.%s", "bmp", Image_LoadBMP, IL_HINT_NO },	// WON menu images
 { "%s%s.%s", "tga", Image_LoadTGA, IL_HINT_NO },	// hl vgui menus
@@ -105,7 +106,6 @@ static const loadpixformat_t load_game[] =
 { "%s%s.%s", "lmp", Image_LoadLMP, IL_HINT_NO },	// hl menu images (cached.wad etc)
 { "%s%s.%s", "fnt", Image_LoadFNT, IL_HINT_HL },	// hl console font (fonts.wad etc)
 { "%s%s.%s", "pal", Image_LoadPAL, IL_HINT_NO },	// install studio\sprite palette
-{ "%s%s.%s", "ktx2", Image_LoadKTX2, IL_HINT_NO },	// ktx2 for world and studio models
 { NULL, NULL, NULL, IL_HINT_NO }
 };
 

--- a/ref/vk/NOTES.md
+++ b/ref/vk/NOTES.md
@@ -1032,7 +1032,7 @@ This would also allow passing arbitrary per-pixel data from shaders, which would
             - `R_VkTextureSkyboxUpload(sides)`
     - if failed and not default already: `R_TextureSetupSky(default)` (recurse)
 
-# 2023-12-14 E34a
+# 2023-12-14 E347
 ## TIL engine imagelib `FS_LoadImage()`:
 1. Pick format based on extension
 2. If no extension is specified, try all supported extensions in sequence.
@@ -1044,3 +1044,38 @@ This would also allow passing arbitrary per-pixel data from shaders, which would
   rotate some compressed format, which will amount to just reordering blocks, and then reordering block
   contents. Mendokusai). Therefore, we can't just replace png sides with compressed ktx2 sides directly.
   KTX2 sides should be pre-rotated.
+
+# 2023-12-15 E348
+## Textures layout
+imagelib image buffer layout:
+	- sides[1|6]
+		- mips[biggest -> smallest]
+			- (pixel data)
+
+KTX2 file layout:
+- mips[smallest -> biggest]
+	- sides[1|6]
+		- (pixel data)
+
+# 2023-12-18 E349
+## Xash vs KTX2/vk cubemap face order
+Vulkan order:
++X, -X, +Y, -Y, +Z, -Z
+rt, lf, bk, ft, up, dn
+ 0,  1,  2,  3,  4,  5
+
+Xash order:
+ft, bk, up, dn, rt, lf
+
+Remap (KTX2 -> xash || xash[face] = KTX2[map[face]]):
+ 3,  2,  4,  5,  0,  1
+
+Remap (xash -> vk, vk[map[face]] = xash[face]):
+ 4,  5,  1,  0,  2,  3
+??? this shoudln't work
+
+default cubemap order:
+xash   vk (remapped)
++Y = -X
++X = +Z
++Z = +Y

--- a/ref/vk/NOTES.md
+++ b/ref/vk/NOTES.md
@@ -1011,3 +1011,23 @@ This would need the same as above, plus:
 - A: probably should still do it on GPU lol
 
 This would also allow passing arbitrary per-pixel data from shaders, which would make shader debugging much much easier.
+
+# 2023-12-12 E346
+## Skyboxes
+### Current state
+- `R_TextureSetupSky()`
+    - called from:
+        ← `vk_scene.c`/`R_NewMap()`
+        ← engine ?? -- seems optional, r_soft doesn't implement it. Set on:
+            - `skybox` console command
+            - certain movevars change, whatever that is
+    - `unloadSkybox()`
+    - for [pbr/, old/] do
+        - `CheckSkybox()`
+            - make sidenames and check whether files exist
+        - `loadSkybox()`
+            - `unloadSkybox()`
+            - make sidenames
+            - `FS_LoadImage()` and `ImageProcess()`
+            - `R_VkTextureSkyboxUpload(sides)`
+    - if failed and not default already: `R_TextureSetupSky(default)` (recurse)

--- a/ref/vk/NOTES.md
+++ b/ref/vk/NOTES.md
@@ -1031,3 +1031,16 @@ This would also allow passing arbitrary per-pixel data from shaders, which would
             - `FS_LoadImage()` and `ImageProcess()`
             - `R_VkTextureSkyboxUpload(sides)`
     - if failed and not default already: `R_TextureSetupSky(default)` (recurse)
+
+# 2023-12-14 E34a
+## TIL engine imagelib `FS_LoadImage()`:
+1. Pick format based on extension
+2. If no extension is specified, try all supported extensions in sequence.
+3. If loading single file failed, try to load it as skybox cubemap:
+   Go through all sides suffixes and try to load them in the similar fashion:
+   if no extension, then try all supported extensions
+
+- `Image_Process()` can only rotate uncompressed formats. (Technically it might be possible to also
+  rotate some compressed format, which will amount to just reordering blocks, and then reordering block
+  contents. Mendokusai). Therefore, we can't just replace png sides with compressed ktx2 sides directly.
+  KTX2 sides should be pre-rotated.

--- a/ref/vk/TODO.md
+++ b/ref/vk/TODO.md
@@ -1,4 +1,4 @@
-# 2023-12-14 E346
+# 2023-12-14 E346-E347
 - [x] Optimize skybox loading, #706
     - [x] Do not load skybox when there are no SURF_DRAWSKY, #579
     - [x] Do not reload the same skybox

--- a/ref/vk/TODO.md
+++ b/ref/vk/TODO.md
@@ -7,11 +7,14 @@
           KTX2 sides should be pre-rotated
     - [ ] KTX2 cubemaps
     - [x] do not generate mips for skybox
+    - [x] support imagelib cubemaps
+    - [x] use imagelib skybox loader
+        - [ ] fix ktx2 sides corruption
 - [x] Hide all SURF_DRAWSKY while retaining skybox, #579
 - [ ] add skybox test
-- [ ] possible issues with TF_NOMIPMAP
-    - [ ] used incorrectly when loading blue noise textures
-    - [ ] what about regular usage?
+- [x] possible issues with TF_NOMIPMAP
+    - [x] used incorrectly when loading blue noise textures
+    - [x] what about regular usage?
 
 # 2023-12-11 E345
 - [x] fix black dielectrics, #666

--- a/ref/vk/TODO.md
+++ b/ref/vk/TODO.md
@@ -1,3 +1,8 @@
+# 2023-12-15 E348
+- [x] fix ktx2 sides corruption
+- [ ] KTX2 cubemaps
+- [ ] add skybox test
+
 # 2023-12-14 E346-E347
 - [x] Optimize skybox loading, #706
     - [x] Do not load skybox when there are no SURF_DRAWSKY, #579
@@ -5,13 +10,10 @@
     - [-] Load skyboxes from KTX2 sides
         → doesn't work as easily, as there's no way to rotate compressed images.
           KTX2 sides should be pre-rotated
-    - [ ] KTX2 cubemaps
     - [x] do not generate mips for skybox
     - [x] support imagelib cubemaps
     - [x] use imagelib skybox loader
-        - [ ] fix ktx2 sides corruption
 - [x] Hide all SURF_DRAWSKY while retaining skybox, #579
-- [ ] add skybox test
 - [x] possible issues with TF_NOMIPMAP
     - [x] used incorrectly when loading blue noise textures
     - [x] what about regular usage?

--- a/ref/vk/TODO.md
+++ b/ref/vk/TODO.md
@@ -1,7 +1,11 @@
+# 2023-12-18 E349
+- [x] KTX2 cubemaps
+- [ ] improve logs "vk/tex: Loaded skybox pbr/env/%.*s"
+- [ ] variable cubemap exposure
+- [ ] add skybox test
+
 # 2023-12-15 E348
 - [x] fix ktx2 sides corruption
-- [ ] KTX2 cubemaps
-- [ ] add skybox test
 
 # 2023-12-14 E346-E347
 - [x] Optimize skybox loading, #706

--- a/ref/vk/TODO.md
+++ b/ref/vk/TODO.md
@@ -1,8 +1,17 @@
+# 2023-12-14 E346
+- [x] Optimize skybox loading, #706
+    - [x] Do not load skybox when there are no SURF_DRAWSKY, #579
+    - [x] Do not reload the same skybox
+    - [ ] Load skyboxes from KTX2
+    - [ ] do not generate mips for skybox
+- [ ] add skybox test
+
 # 2023-12-11 E345
-- [x] fix incorrect basecolor brdf multiplication, #666
+- [x] fix black dielectrics, #666
+    - [x] fix incorrect basecolor brdf multiplication, #666
+    - [x] fixup skybox glitches caused by #666 fix
 - [ ] Patch overlay textures (#696) → turned out to be much more difficult than expected.
 - [x] Do not patch sprite textures for traditional raster, #695
-- [x] fixup skybox glitches caused by #666 fix
 
 # 2023-12-05 E342
 - [x] tone down the specular indirect blur
@@ -17,7 +26,6 @@ Longer-term agenda for current season:
 - [ ] Tools:
 	- [ ] Shader profiling. Measure impact of changes. Regressions.
 - [ ] Better PBR math, e.g.:
-	- [ ] fix black dielectrics, #666
 - [ ] Transparency:
 	- [ ] Figure out why additive transparency differs visibly from raster
 	- [ ] Extract and specialize effects, e.g.

--- a/ref/vk/TODO.md
+++ b/ref/vk/TODO.md
@@ -2,9 +2,16 @@
 - [x] Optimize skybox loading, #706
     - [x] Do not load skybox when there are no SURF_DRAWSKY, #579
     - [x] Do not reload the same skybox
-    - [ ] Load skyboxes from KTX2
-    - [ ] do not generate mips for skybox
+    - [-] Load skyboxes from KTX2 sides
+        → doesn't work as easily, as there's no way to rotate compressed images.
+          KTX2 sides should be pre-rotated
+    - [ ] KTX2 cubemaps
+    - [x] do not generate mips for skybox
+- [x] Hide all SURF_DRAWSKY while retaining skybox, #579
 - [ ] add skybox test
+- [ ] possible issues with TF_NOMIPMAP
+    - [ ] used incorrectly when loading blue noise textures
+    - [ ] what about regular usage?
 
 # 2023-12-11 E345
 - [x] fix black dielectrics, #666

--- a/ref/vk/data/valve/luchiki/maps/c2a5.patch
+++ b/ref/vk/data/valve/luchiki/maps/c2a5.patch
@@ -4,4 +4,5 @@
 }
 {
 "_xvk_smoothing_threshold" "54" // FIXME
+"_xvk_remove_all_sky_surfaces" "1"
 }

--- a/ref/vk/r_speeds.c
+++ b/ref/vk/r_speeds.c
@@ -3,6 +3,7 @@
 #include "vk_framectl.h"
 #include "vk_cvar.h"
 #include "vk_combuf.h"
+#include "stringview.h"
 
 #include "profiler.h"
 
@@ -302,23 +303,9 @@ static void handlePause( uint32_t prev_frame_index ) {
 	}
 }
 
-// TODO move this to vk_common or something
-int stringViewCmp(const_string_view_t sv, const char* s) {
-	for (int i = 0; i < sv.len; ++i) {
-		const int d = sv.s[i] - s[i];
-		if (d != 0)
-			return d;
-		if (s[i] == '\0')
-			return 1;
-	}
-
-	// Check that both strings end the same
-	return '\0' - s[sv.len];
-}
-
 static int findMetricIndexByName( const_string_view_t name) {
 	for (int i = 0; i < g_speeds.metrics_count; ++i) {
-		if (stringViewCmp(name, g_speeds.metrics[i].name) == 0)
+		if (svCmp(name, g_speeds.metrics[i].name) == 0)
 			return i;
 	}
 
@@ -327,7 +314,7 @@ static int findMetricIndexByName( const_string_view_t name) {
 
 static int findGraphIndexByName( const_string_view_t name) {
 	for (int i = 0; i < g_speeds.graphs_count; ++i) {
-		if (stringViewCmp(name, g_speeds.graphs[i].name) == 0)
+		if (svCmp(name, g_speeds.graphs[i].name) == 0)
 			return i;
 	}
 

--- a/ref/vk/r_textures.h
+++ b/ref/vk/r_textures.h
@@ -23,6 +23,8 @@ typedef struct vk_textures_global_s
 
 	// TODO wire it up for ref_interface_t return
 	qboolean fCustomSkybox;
+
+	qboolean current_map_has_surf_sky;
 } vk_textures_global_t;
 
 // TODO rename this consistently
@@ -37,7 +39,7 @@ void R_TexturesShutdown( void );
 int R_TextureFindByName( const char *name );
 const char* R_TextureGetNameByIndex( unsigned int texnum );
 
-void R_TextureSetupSky( const char *skyboxname );
+void R_TextureSetupCustomSky( const char *skyboxname );
 
 int R_TextureUploadFromFile( const char *name, const byte *buf, size_t size, int flags );
 int R_TextureUploadFromBuffer( const char *name, rgbdata_t *pic, texFlags_t flags, qboolean update_only );
@@ -67,3 +69,5 @@ int R_TextureFindByNameLike( const char *texture_name );
 
 struct vk_texture_s;
 struct vk_texture_s *R_TextureGetByIndex( uint index );
+
+void R_TextureSetupSky( const char *skyboxname, qboolean force_reload );

--- a/ref/vk/r_textures.h
+++ b/ref/vk/r_textures.h
@@ -71,3 +71,8 @@ struct vk_texture_s;
 struct vk_texture_s *R_TextureGetByIndex( uint index );
 
 void R_TextureSetupSky( const char *skyboxname, qboolean force_reload );
+
+typedef struct r_skybox_info_s {
+	float exposure;
+} r_skybox_info_t;
+r_skybox_info_t R_TexturesGetSkyboxInfo( void );

--- a/ref/vk/shaders/ray_interop.h
+++ b/ref/vk/shaders/ray_interop.h
@@ -201,6 +201,7 @@ struct UniformBuffer {
 	float ray_cone_width;
 	uint random_seed;
 	uint frame_counter;
+	float skybox_exposure;
 
 	uint debug_display_only;
 };

--- a/ref/vk/shaders/ray_primary.comp
+++ b/ref/vk/shaders/ray_primary.comp
@@ -115,7 +115,7 @@ void main() {
 		L = rayQueryGetIntersectionTEXT(rq, true);
 	} else {
 		// Draw skybox when nothing is hit
-		payload.emissive.rgb = texture(skybox, ray.direction).rgb;
+		payload.emissive.rgb = texture(skybox, ray.direction).rgb * ubo.ubo.skybox_exposure;
 	}
 
 	traceSimpleBlending(ray.origin, ray.direction, L, payload.emissive.rgb, payload.base_color_a.rgb);

--- a/ref/vk/shaders/ray_primary.rchit
+++ b/ref/vk/shaders/ray_primary.rchit
@@ -41,7 +41,7 @@ void main() {
 	const Kusok kusok = getKusok(geom.kusok_index);
 
 	if (kusok.material.tex_base_color == TEX_BASE_SKYBOX) {
-		payload.emissive.rgb = texture(skybox, gl_WorldRayDirectionEXT).rgb;
+		payload.emissive.rgb = texture(skybox, gl_WorldRayDirectionEXT).rgb * ubo.ubo.skybox_exposure;
 		return;
 	} else {
 		const vec4 color = getModelHeader(gl_InstanceID).color * kusok.material.base_color;

--- a/ref/vk/shaders/ray_primary_hit.glsl
+++ b/ref/vk/shaders/ray_primary_hit.glsl
@@ -31,7 +31,7 @@ void primaryRayHit(rayQueryEXT rq, inout RayPayloadPrimary payload) {
 	if (kusok.material.tex_base_color == TEX_BASE_SKYBOX) {
 		// Mark as non-geometry
 		payload.hit_t.w = -payload.hit_t.w;
-		payload.emissive.rgb = texture(skybox, rayDirection).rgb;
+		payload.emissive.rgb = texture(skybox, rayDirection).rgb * ubo.ubo.skybox_exposure;
 		return;
 	} else {
 		payload.base_color_a = sampleTexture(material.tex_base_color, geom.uv, geom.uv_lods);

--- a/ref/vk/stringview.c
+++ b/ref/vk/stringview.c
@@ -1,0 +1,41 @@
+#include "stringview.h"
+
+#include <string.h>
+
+const_string_view_t svFromNullTerminated( const char *s ) {
+	return (const_string_view_t){.len = s?strlen(s):0, .s = s};
+}
+
+int svCmp(const_string_view_t sv, const char* s) {
+	for (int i = 0; i < sv.len; ++i) {
+		const int d = sv.s[i] - s[i];
+		if (d != 0)
+			return d;
+		if (s[i] == '\0')
+			return 1;
+	}
+
+	// Check that both strings end the same
+	return '\0' - s[sv.len];
+}
+
+const_string_view_t svStripExtension(const_string_view_t sv) {
+	for (int i = sv.len - 1; i >= 0; --i) {
+		const char c = sv.s[i];
+		if (c == '.')
+			return (const_string_view_t){ .len = i, .s = sv.s };
+
+		if (c == '/' || c == '\\' || c == ':')
+			break;
+	}
+
+	return sv;
+}
+
+#define MIN(a,b) ((a)<(b)?(a):(b))
+
+void svStrncpy(const_string_view_t sv, char *dest, int size) {
+	const int to_copy = MIN(sv.len, size - 1);
+	memcpy(dest, sv.s, to_copy);
+	dest[to_copy] = '\0';
+}

--- a/ref/vk/stringview.h
+++ b/ref/vk/stringview.h
@@ -1,0 +1,13 @@
+#pragma once
+
+typedef struct {
+	const char *s;
+	int len;
+} const_string_view_t;
+
+const_string_view_t svFromNullTerminated( const char *s );
+
+int svCmp(const_string_view_t sv, const char* s);
+void svStrncpy(const_string_view_t sv, char *dest, int size);
+
+const_string_view_t svStripExtension(const_string_view_t sv);

--- a/ref/vk/vk_brush.c
+++ b/ref/vk/vk_brush.c
@@ -83,6 +83,7 @@ typedef struct {
 	int animated_count;
 	int conveyors_count;
 	int conveyors_vertices_count;
+	int sky_surfaces_count;
 
 	water_model_sizes_t water, side_water;
 } model_sizes_t;
@@ -992,8 +993,10 @@ static model_sizes_t computeSizes( const model_t *mod, qboolean is_worldmodel ) 
 			sizes.conveyors_count++;
 			sizes.conveyors_vertices_count += surf->numedges;
 			break;
-		case BrushSurface_Regular:
 		case BrushSurface_Sky:
+			sizes.sky_surfaces_count++;
+			break;
+		case BrushSurface_Regular:
 			break;
 		}
 
@@ -1609,6 +1612,11 @@ qboolean R_BrushModelLoad( model_t *mod, qboolean is_worldmodel ) {
 	bmodel->prev_time = gpGlobals->time;
 
 	const model_sizes_t sizes = computeSizes( mod, is_worldmodel );
+
+	if (is_worldmodel) {
+		tglob.current_map_has_surf_sky = sizes.sky_surfaces_count != 0;
+		DEBUG("sky_surfaces_count=%d, current_map_has_surf_sky=%d", sizes.sky_surfaces_count, tglob.current_map_has_surf_sky);
+	}
 
 	if (sizes.num_surfaces != 0) {
 		if (!createRenderModel(mod, bmodel, sizes, is_worldmodel)) {

--- a/ref/vk/vk_brush.c
+++ b/ref/vk/vk_brush.c
@@ -995,6 +995,10 @@ static model_sizes_t computeSizes( const model_t *mod, qboolean is_worldmodel ) 
 			break;
 		case BrushSurface_Sky:
 			sizes.sky_surfaces_count++;
+
+			// Do not count towards surfaces that we'll load (still need to count if for the purpose of loading skybox)
+			if (g_map_entities.remove_all_sky_surfaces)
+				continue;
 			break;
 		case BrushSurface_Regular:
 			break;
@@ -1321,8 +1325,10 @@ static qboolean fillBrushSurfaces(fill_geometries_args_t args) {
 				break;
 			case BrushSurface_Conveyor:
 				break;
-			case BrushSurface_Regular:
 			case BrushSurface_Sky:
+				if (g_map_entities.remove_all_sky_surfaces)
+					continue;
+			case BrushSurface_Regular:
 				break;
 			}
 

--- a/ref/vk/vk_common.h
+++ b/ref/vk/vk_common.h
@@ -28,12 +28,5 @@ inline static int clampi32(int v, int min, int max) {
 	return v;
 }
 
-typedef struct {
-	const char *s;
-	int len;
-} const_string_view_t;
-
-int stringViewCmp(const_string_view_t sv, const char* s);
-
 extern ref_api_t gEngine;
 extern ref_globals_t *gpGlobals;

--- a/ref/vk/vk_logs.c
+++ b/ref/vk/vk_logs.c
@@ -1,5 +1,6 @@
 #include "vk_logs.h"
 #include "vk_cvar.h"
+#include "stringview.h"
 
 uint32_t g_log_debug_bits = 0;
 
@@ -21,7 +22,7 @@ void R_LogSetVerboseModules( const char *p ) {
 
 		for (int i = 0; i < COUNTOF(g_log_module_pairs); ++i) {
 			const struct log_pair_t *const pair = g_log_module_pairs + i;
-			if (stringViewCmp(name, pair->name) == 0) {
+			if (svCmp(name, pair->name) == 0) {
 				gEngine.Con_Reportf("Enabling verbose logs for module \"%.*s\"\n", name.len, name.s);
 				bit = pair->bit;
 				break;

--- a/ref/vk/vk_mapents.c
+++ b/ref/vk/vk_mapents.c
@@ -733,6 +733,11 @@ static void parseEntities( char *string, qboolean is_patch ) {
 							if (have_fields & Field__xvk_smoothing_group) {
 								addSmoothingGroup(&values);
 							}
+
+							if (have_fields & Field__xvk_remove_all_sky_surfaces) {
+								DEBUG("_xvk_remove_all_sky_surfaces=%d", values._xvk_remove_all_sky_surfaces);
+								g_map_entities.remove_all_sky_surfaces = values._xvk_remove_all_sky_surfaces;
+							}
 						}
 					}
 					break;

--- a/ref/vk/vk_mapents.h
+++ b/ref/vk/vk_mapents.h
@@ -37,6 +37,7 @@
 	X(25, int, _xvk_smooth_entire_model, Int) \
 	X(26, int_array_t, _xvk_smoothing_excluded, IntArray) \
 	X(27, float, _xvk_tex_rotate, Float) \
+	X(28, int, _xvk_remove_all_sky_surfaces, Int) \
 
 /* NOTE: not used
 	X(23, int, renderamt, Int) \
@@ -175,6 +176,8 @@ typedef struct {
 		int excluded_count;
 		int excluded[MAX_EXCLUDED_SMOOTHING_SURFACES];
 	} smoothing;
+
+	qboolean remove_all_sky_surfaces;
 } xvk_map_entities_t;
 
 // TODO expose a bunch of things here as funtions, not as internal structures

--- a/ref/vk/vk_rmain.c
+++ b/ref/vk/vk_rmain.c
@@ -559,7 +559,7 @@ static const ref_interface_t gReffuncs =
 	.R_GetTextureOriginalBuffer = R_GetTextureOriginalBuffer_UNUSED,
 	.GL_LoadTextureFromBuffer = R_TextureUploadFromBuffer,
 	.GL_ProcessTexture = GL_ProcessTexture_UNUSED,
-	.R_SetupSky = R_TextureSetupSky,
+	.R_SetupSky = R_TextureSetupCustomSky,
 
 	// 2D
 	R_Set2DMode,

--- a/ref/vk/vk_rtx.c
+++ b/ref/vk/vk_rtx.c
@@ -216,6 +216,7 @@ static void prepareUniformBuffer( const vk_ray_frame_render_args_t *args, int fr
 	ubo->res[1] = frame_height;
 	ubo->ray_cone_width = atanf((2.0f*tanf(DEG2RAD(fov_angle_y) * 0.5f)) / (float)frame_height);
 	ubo->frame_counter = frame_counter;
+	ubo->skybox_exposure = R_TexturesGetSkyboxInfo().exposure;
 
 	parseDebugDisplayValue();
 	if (g_rtx.debug.rt_debug_display_only_value) {

--- a/ref/vk/vk_rtx.c
+++ b/ref/vk/vk_rtx.c
@@ -118,13 +118,14 @@ static int findResourceOrEmptySlot(const char *name) {
 	return -1;
 }
 
-void VK_RayNewMap( void ) {
+void VK_RayNewMapBegin( void ) {
 	RT_VkAccelNewMap();
 	RT_RayModel_Clear();
+}
 
+void VK_RayNewMapEnd( void ) {
 	g_rtx.res[ExternalResource_skybox].resource = (vk_resource_t){
 		.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-		// FIXME we should pick tglob.dii_all_textures here directly
 		.value = (vk_descriptor_value_t){
 			.image = R_VkTexturesGetSkyboxDescriptorImageInfo(),
 		},
@@ -132,7 +133,6 @@ void VK_RayNewMap( void ) {
 
 	g_rtx.res[ExternalResource_blue_noise_texture].resource = (vk_resource_t){
 		.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-		// FIXME we should pick tglob.dii_all_textures here directly
 		.value = (vk_descriptor_value_t){
 			.image = R_VkTexturesGetBlueNoiseImageInfo(),
 		},

--- a/ref/vk/vk_rtx.h
+++ b/ref/vk/vk_rtx.h
@@ -27,7 +27,8 @@ typedef struct {
 } vk_ray_frame_render_args_t;
 void VK_RayFrameEnd(const vk_ray_frame_render_args_t* args);
 
-void VK_RayNewMap( void );
+void VK_RayNewMapBegin( void );
+void VK_RayNewMapEnd( void );
 
 qboolean VK_RayInit( void );
 void VK_RayShutdown( void );

--- a/ref/vk/vk_textures.c
+++ b/ref/vk/vk_textures.c
@@ -58,9 +58,6 @@ void BuildMipMap( byte *in, int srcWidth, int srcHeight, int srcDepth, int flags
 static VkSampler pickSamplerForFlags( texFlags_t flags );
 static qboolean uploadTexture(int index, vk_texture_t *tex, rgbdata_t *const *const layers, int num_layers, qboolean cubemap, colorspace_hint_e colorspace_hint);
 
-// FIXME should be static
-void unloadSkybox( void );
-
 // Hardcode blue noise texture size to 64x64x64
 #define BLUE_NOISE_SIZE 64
 #define BLUE_NOISE_NAME_F "bluenoise/LDR_RGBA_%d.png"
@@ -189,7 +186,7 @@ qboolean R_VkTexturesInit( void ) {
 static void textureDestroy( unsigned int index );
 
 void R_VkTexturesShutdown( void ) {
-	unloadSkybox();
+	R_VkTexturesSkyboxUnload();
 	R_VkTextureDestroy(-1, &g_vktextures.cubemap_placeholder);
 	R_VkTextureDestroy(-1, &g_vktextures.blue_noise);
 
@@ -581,13 +578,12 @@ void R_VkTextureDestroy( int index, vk_texture_t *tex ) {
 	// TODO tex->vk.descriptor_unorm = VK_NULL_HANDLE;
 }
 
-void unloadSkybox( void ) {
+void R_VkTexturesSkyboxUnload(void) {
+	DEBUG("%s", __FUNCTION__);
 	if (g_vktextures.skybox_cube.vk.image.image) {
 		R_VkTextureDestroy( -1, &g_vktextures.skybox_cube );
 		memset(&g_vktextures.skybox_cube, 0, sizeof(g_vktextures.skybox_cube));
 	}
-
-	tglob.fCustomSkybox = false;
 }
 
 VkDescriptorImageInfo R_VkTexturesGetSkyboxDescriptorImageInfo( void ) {
@@ -604,6 +600,11 @@ qboolean R_VkTexturesSkyboxUpload( const char *name, rgbdata_t *const sides[6], 
 	vk_texture_t *const dest = placeholder ? &g_vktextures.cubemap_placeholder : &g_vktextures.skybox_cube;
 	Q_strncpy( TEX_NAME(dest), name, sizeof( TEX_NAME(dest) ));
 	return uploadTexture(-1, dest, sides, 6, true, colorspace_hint);
+}
+
+qboolean R_VkTexturesSkyboxUploadKTX( const char *filename ) {
+	ERR("%s(%s): not implemented", __FUNCTION__, filename);
+	return false;
 }
 
 VkDescriptorSet R_VkTextureGetDescriptorUnorm( uint index ) {

--- a/ref/vk/vk_textures.c
+++ b/ref/vk/vk_textures.c
@@ -52,17 +52,16 @@ static struct {
 // Exported from r_textures.h
 size_t CalcImageSize( pixformat_t format, int width, int height, int depth );
 int CalcMipmapCount( int width, int height, int depth, uint32_t flags, qboolean haveBuffer );
-qboolean validatePicLayers(const char* const name, rgbdata_t *const *const layers, int num_layers);
 void BuildMipMap( byte *in, int srcWidth, int srcHeight, int srcDepth, int flags );
 
 static VkSampler pickSamplerForFlags( texFlags_t flags );
-static qboolean uploadTexture(int index, vk_texture_t *tex, rgbdata_t *const *const layers, int num_layers, qboolean cubemap, colorspace_hint_e colorspace_hint);
+static qboolean uploadTexture(int index, vk_texture_t *tex, const rgbdata_t *layers, colorspace_hint_e colorspace_hint);
 
 // Hardcode blue noise texture size to 64x64x64
 #define BLUE_NOISE_SIZE 64
 #define BLUE_NOISE_NAME_F "bluenoise/LDR_RGBA_%d.png"
 
-static void generateFallbackNoiseTextures( rgbdata_t *pic ) {
+static void generateFallbackNoiseTextures( const rgbdata_t *pic ) {
 	ERR("Generating bad quality regular noise textures as a fallback for blue noise textures");
 
 	const int blue_noise_count = pic->size / sizeof(uint32_t);
@@ -80,11 +79,11 @@ static void loadBlueNoiseTextures(void) {
 	const size_t blue_noise_count = BLUE_NOISE_SIZE * BLUE_NOISE_SIZE * BLUE_NOISE_SIZE;
 	const size_t blue_noise_size = blue_noise_count * sizeof(uint32_t);
 	uint32_t *const scratch = Mem_Malloc(vk_core.pool /* TODO textures pool */, blue_noise_size);
-	rgbdata_t pic = {
+	const rgbdata_t pic = {
 		.width = BLUE_NOISE_SIZE,
 		.height = BLUE_NOISE_SIZE,
 		.depth = BLUE_NOISE_SIZE,
-		.flags = TF_NOMIPMAP,
+		.flags = 0,
 		.type = PF_RGBA_32,
 		.size = blue_noise_size,
 		.buffer = (byte*)scratch,
@@ -136,9 +135,8 @@ static void loadBlueNoiseTextures(void) {
 
 	const char *const name = fail ? "*bluenoise/pcg_fallback" : "*bluenoise";
 	Q_strncpy(g_vktextures.blue_noise.hdr_.key, name, sizeof(g_vktextures.blue_noise.hdr_.key));
-	rgbdata_t *pica[1] = {&pic};
-	const qboolean is_cubemap = false;
-	ASSERT(uploadTexture(-1, &g_vktextures.blue_noise, pica, 1, is_cubemap, kColorspaceLinear));
+	g_vktextures.blue_noise.flags = TF_NOMIPMAP;
+	ASSERT(uploadTexture(-1, &g_vktextures.blue_noise, &pic, kColorspaceLinear));
 	Mem_Free(scratch);
 }
 
@@ -501,36 +499,44 @@ static const char* getColorspaceHintName(colorspace_hint_e ch) {
 	return "INVALID";
 }
 
-static qboolean uploadTexture(int index, vk_texture_t *tex, rgbdata_t *const *const layers, int num_layers, qboolean cubemap, colorspace_hint_e colorspace_hint) {
+// xash imagelib cubemap layer order is not the one that vulkan expects
+static const int g_remap_cube_layer[6] = {
+	/* ft = */ 3,
+	/* bk = */ 2,
+	/* up = */ 4,
+	/* dn = */ 5,
+	/* rt = */ 0,
+	/* lf = */ 1,
+};
+
+static qboolean uploadTexture(int index, vk_texture_t *tex, const rgbdata_t *pic, colorspace_hint_e colorspace_hint) {
 	tex->total_size = 0;
 
-	if (num_layers == 1 && layers[0]->type == PF_KTX2_RAW) {
-		if (!uploadRawKtx2(index, tex, layers[0]))
+	if (pic->type == PF_KTX2_RAW) {
+		if (!uploadRawKtx2(index, tex, pic))
 			return false;
 	} else {
-		const int width = layers[0]->width;
-		const int height = layers[0]->height;
-		const int depth = Q_max(1, layers[0]->depth);
-		const qboolean compute_mips = layers[0]->type == PF_RGBA_32 && layers[0]->numMips < 2;
-		const VkFormat format = VK_GetFormat(layers[0]->type, colorspace_hint);
-		const int mipCount = compute_mips ? CalcMipmapCount( width, height, depth, tex->flags, true ) : layers[0]->numMips;
+		const int width = pic->width;
+		const int height = pic->height;
+		const int depth = Q_max(1, pic->depth);
+		const qboolean compute_mips = !(tex->flags & TF_NOMIPMAP) && pic->type == PF_RGBA_32 && pic->numMips < 2;
+		const VkFormat format = VK_GetFormat(pic->type, colorspace_hint);
+		const int mipCount = compute_mips ? CalcMipmapCount( width, height, depth, tex->flags, true ) : Q_max(1, pic->numMips);
+		const qboolean is_cubemap = !!(pic->flags & IMAGE_CUBEMAP);
 
 		if (format == VK_FORMAT_UNDEFINED) {
-			ERR("Unsupported PF format %d", layers[0]->type);
+			ERR("Unsupported PF format %d", pic->type);
 			return false;
 		}
 
-		if (!validatePicLayers(TEX_NAME(tex), layers, num_layers))
-			return false;
-
-		DEBUG("Uploading texture[%d] %s, %dx%d fmt=%s(%s) cs=%s mips=%d(build=%d), layers=%d",
+		DEBUG("Uploading texture[%d] %s, %dx%d fmt=%s(%s) cs=%s mips=%d(build=%d), is_cubemap=%d",
 			index, TEX_NAME(tex), width, height,
-			getPFName(layers[0]->type), R_VkFormatName(format),
+			getPFName(pic->type), R_VkFormatName(format),
 			getColorspaceHintName(colorspace_hint),
-			mipCount, compute_mips, num_layers);
+			mipCount, compute_mips, is_cubemap);
 
 		// TODO (not sure why, but GL does this)
-		// if( !ImageCompressed( layers->type ) && !FBitSet( tex->flags, TF_NOMIPMAP ) && FBitSet( layers->flags, IMAGE_ONEBIT_ALPHA ))
+		// if( !ImageCompressed( pic->type ) && !FBitSet( tex->flags, TF_NOMIPMAP ) && FBitSet( pic->flags, IMAGE_ONEBIT_ALPHA ))
 		// 	data = GL_ApplyFilter( data, tex->width, tex->height );
 
 		{
@@ -540,13 +546,13 @@ static qboolean uploadTexture(int index, vk_texture_t *tex, rgbdata_t *const *co
 				.height = height,
 				.depth = depth,
 				.mips = mipCount,
-				.layers = num_layers,
+				.layers = is_cubemap ? 6 : 1,
 				.format = format,
 				.tiling = VK_IMAGE_TILING_OPTIMAL,
 				.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT,
 				.flags = 0
-					| ((layers[0]->flags & IMAGE_HAS_ALPHA) ? 0 : kVkImageFlagIgnoreAlpha)
-					| (cubemap ? kVkImageFlagIsCubemap : 0)
+					| ((pic->flags & IMAGE_HAS_ALPHA) ? 0 : kVkImageFlagIgnoreAlpha)
+					| (is_cubemap ? kVkImageFlagIsCubemap : 0)
 					| (colorspace_hint == kColorspaceGamma ? kVkImageFlagCreateUnormView : 0),
 			};
 
@@ -561,17 +567,16 @@ static qboolean uploadTexture(int index, vk_texture_t *tex, rgbdata_t *const *co
 		{
 			R_VkImageUploadBegin(&tex->vk.image);
 
-			for (int layer = 0; layer < num_layers; ++layer) {
-				const rgbdata_t *const pic = layers[layer];
-				byte *buf = pic->buffer;
-
+			byte *buf = pic->buffer;
+			const int layers_count = is_cubemap ? 6 : 1;
+			for (int layer = 0; layer < layers_count; ++layer) {
 				for (int mip = 0; mip < mipCount; ++mip) {
 					const int width = Q_max( 1, ( pic->width >> mip ));
 					const int height = Q_max( 1, ( pic->height >> mip ));
 					const int depth = Q_max( 1, ( pic->depth >> mip ));
 					const size_t mip_size = CalcImageSize( pic->type, width, height, depth );
 
-					R_VkImageUploadSlice(&tex->vk.image, layer, mip, mip_size, buf);
+					R_VkImageUploadSlice(&tex->vk.image, is_cubemap ? g_remap_cube_layer[layer] : 0, mip, mip_size, buf);
 					tex->total_size += mip_size;
 
 					// Build mip in place for the next mip level
@@ -581,6 +586,10 @@ static qboolean uploadTexture(int index, vk_texture_t *tex, rgbdata_t *const *co
 					} else {
 						buf += mip_size;
 					}
+				}
+
+				if (compute_mips) {
+					buf += CalcImageSize(pic->type, width, height, depth);
 				}
 			}
 
@@ -595,8 +604,8 @@ static qboolean uploadTexture(int index, vk_texture_t *tex, rgbdata_t *const *co
 	return true;
 }
 
-qboolean R_VkTextureUpload(int index, vk_texture_t *tex, rgbdata_t *const *const layers, int num_layers, colorspace_hint_e colorspace_hint) {
-	return uploadTexture( index, tex, layers, num_layers, false, colorspace_hint );
+qboolean R_VkTextureUpload(int index, vk_texture_t *tex, const rgbdata_t *pic, colorspace_hint_e colorspace_hint) {
+	return uploadTexture( index, tex, pic, colorspace_hint );
 }
 
 void R_VkTextureDestroy( int index, vk_texture_t *tex ) {
@@ -638,16 +647,12 @@ VkDescriptorImageInfo R_VkTexturesGetSkyboxDescriptorImageInfo( void ) {
 	};
 }
 
-qboolean R_VkTexturesSkyboxUploadSides( const char *name, rgbdata_t *const sides[6], colorspace_hint_e colorspace_hint, qboolean placeholder) {
+qboolean R_VkTexturesSkyboxUpload( const char *name, const rgbdata_t *pic, colorspace_hint_e colorspace_hint, qboolean placeholder) {
 	vk_texture_t *const dest = placeholder ? &g_vktextures.cubemap_placeholder : &g_vktextures.skybox_cube;
 	Q_strncpy( TEX_NAME(dest), name, sizeof( TEX_NAME(dest) ));
 	dest->flags |= TF_NOMIPMAP;
-	return uploadTexture(-1, dest, sides, 6, true, colorspace_hint);
-}
-
-qboolean R_VkTexturesSkyboxUpload( const char *name, rgbdata_t *const pic ) {
-	ERR("%s(%s): not implemented", __FUNCTION__, name);
-	return false;
+	ASSERT(pic->flags & IMAGE_CUBEMAP);
+	return uploadTexture(-1, dest, pic, colorspace_hint);
 }
 
 VkDescriptorSet R_VkTextureGetDescriptorUnorm( uint index ) {

--- a/ref/vk/vk_textures.h
+++ b/ref/vk/vk_textures.h
@@ -34,11 +34,10 @@ typedef struct vk_texture_s
 qboolean R_VkTexturesInit( void );
 void R_VkTexturesShutdown( void );
 
-qboolean R_VkTexturesSkyboxUploadSides( const char *name, rgbdata_t *const sides[6], colorspace_hint_e colorspace_hint, qboolean placeholder);
-qboolean R_VkTexturesSkyboxUpload( const char *name, rgbdata_t *const pic );
+qboolean R_VkTexturesSkyboxUpload( const char *name, const rgbdata_t *pic, colorspace_hint_e colorspace_hint, qboolean placeholder);
 void R_VkTexturesSkyboxUnload(void);
 
-qboolean R_VkTextureUpload(int index, vk_texture_t *tex, rgbdata_t *const *const layers, int num_layers, colorspace_hint_e colorspace_hint);
+qboolean R_VkTextureUpload(int index, vk_texture_t *tex, const rgbdata_t *pic, colorspace_hint_e colorspace_hint);
 void R_VkTextureDestroy(int index, vk_texture_t *tex);
 
 VkDescriptorImageInfo R_VkTexturesGetSkyboxDescriptorImageInfo( void );

--- a/ref/vk/vk_textures.h
+++ b/ref/vk/vk_textures.h
@@ -35,6 +35,8 @@ qboolean R_VkTexturesInit( void );
 void R_VkTexturesShutdown( void );
 
 qboolean R_VkTexturesSkyboxUpload( const char *name, rgbdata_t *const sides[6], colorspace_hint_e colorspace_hint, qboolean placeholder);
+qboolean R_VkTexturesSkyboxUploadKTX( const char *filename );
+void R_VkTexturesSkyboxUnload(void);
 
 qboolean R_VkTextureUpload(int index, vk_texture_t *tex, rgbdata_t *const *const layers, int num_layers, colorspace_hint_e colorspace_hint);
 void R_VkTextureDestroy(int index, vk_texture_t *tex);

--- a/ref/vk/vk_textures.h
+++ b/ref/vk/vk_textures.h
@@ -34,8 +34,8 @@ typedef struct vk_texture_s
 qboolean R_VkTexturesInit( void );
 void R_VkTexturesShutdown( void );
 
-qboolean R_VkTexturesSkyboxUpload( const char *name, rgbdata_t *const sides[6], colorspace_hint_e colorspace_hint, qboolean placeholder);
-qboolean R_VkTexturesSkyboxUploadKTX( const char *filename );
+qboolean R_VkTexturesSkyboxUploadSides( const char *name, rgbdata_t *const sides[6], colorspace_hint_e colorspace_hint, qboolean placeholder);
+qboolean R_VkTexturesSkyboxUpload( const char *name, rgbdata_t *const pic );
 void R_VkTexturesSkyboxUnload(void);
 
 qboolean R_VkTextureUpload(int index, vk_texture_t *tex, rgbdata_t *const *const layers, int num_layers, colorspace_hint_e colorspace_hint);


### PR DESCRIPTION
- [x] #706 
  - [x] Do not load skybox if map doesn't have any `SURF_DRAWSKY` surfaces.
  - [x] Cache: do not reload the same skybox.
  - [x] Enable loading packed KTX2 cubemaps as skyboxes in engine/imagelib
- [x] Reuse existing imagelib cubemap loading routines, remove custom skybox loading code
- [x] Allow hiding `SURF_DRAWSKY` surfaces via `"_xvk_remove_all_sky_surfaces" "1"`, #579 
- [x] #677 
  - [x] Add skybox exposure control for HDR skyboxes
  - [x] Allow reloading skyboxes when reloading patches