### PR TITLE
Modules API

### DIFF
--- a/ref/vk/camera.h
+++ b/ref/vk/camera.h
@@ -28,5 +28,7 @@ void R_SetupCamera( const struct ref_viewpass_s *rvp );
 int R_WorldToScreen( const vec3_t point, vec3_t screen );
 int TriWorldToScreen( const float *world, float *screen );
 
+int CL_FxBlend( struct cl_entity_s *e );
+
 // TODO move to infotool.h
 void XVK_CameraDebugPrintCenterEntity( void );

--- a/ref/vk/camera.h
+++ b/ref/vk/camera.h
@@ -28,6 +28,7 @@ void R_SetupCamera( const struct ref_viewpass_s *rvp );
 int R_WorldToScreen( const vec3_t point, vec3_t screen );
 int TriWorldToScreen( const float *world, float *screen );
 
+struct cl_entity_s;
 int CL_FxBlend( struct cl_entity_s *e );
 
 // TODO move to infotool.h

--- a/ref/vk/r_textures.c
+++ b/ref/vk/r_textures.c
@@ -952,7 +952,7 @@ static qboolean Impl_Init( void ) {
 	// This probably needs some reorganization / change of logic.
 	g_module_textures.init_caller = &g_module_textures_api;
 	if ( !g_module_textures.Init() ) {
-		ERR( "Couldn't initialize '%s' submodule.", g_module_textures );
+		ERR( "Couldn't initialize '%s' submodule.", g_module_textures.name );
 		g_module_textures_api.state = RVkModuleState_NotInitialized;
 		return false;
 	}

--- a/ref/vk/r_textures.h
+++ b/ref/vk/r_textures.h
@@ -1,11 +1,15 @@
 #pragma once
 
+#include "vk_module.h"
+
 #include "const.h" // required for com_model.h, ref_api.h
 #include "cvardef.h" // required for ref_api.h
 #include "com_model.h" // required for ref_api.h
 #include "ref_api.h" // texFlags_t
 
 #define MAX_LIGHTMAPS 256
+
+extern RVkModule g_module_textures_api;
 
 typedef struct vk_textures_global_s
 {
@@ -29,9 +33,6 @@ typedef struct vk_textures_global_s
 
 // TODO rename this consistently
 extern vk_textures_global_t tglob;
-
-qboolean R_TexturesInit( void );
-void R_TexturesShutdown( void );
 
 ////////////////////////////////////////////////////////////
 // Ref interface functions, exported

--- a/ref/vk/vk_beams.h
+++ b/ref/vk/vk_beams.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include "vk_module.h"
 #include "xash3d_types.h"
+
+extern RVkModule g_module_beams;
 
 struct cl_entity_s;
 struct beam_s;
@@ -9,5 +12,3 @@ qboolean R_BeamCull( const vec3_t start, const vec3_t end, qboolean pvsOnly );
 
 void R_BeamDrawCustomEntity( struct cl_entity_s *ent, float frametime );
 void R_BeamDraw( struct beam_s *pbeam, float frametime );
-
-qboolean R_BeamInit(void);

--- a/ref/vk/vk_brush.h
+++ b/ref/vk/vk_brush.h
@@ -1,15 +1,16 @@
 #pragma once
 
+#include "vk_module.h"
+
 #include "xash3d_types.h"
 #include "vk_render.h" // cl_entity_t
+
+extern RVkModule g_module_brush;
 
 struct ref_viewpass_s;
 struct draw_list_s;
 struct model_s;
 struct cl_entity_s;
-
-qboolean R_BrushInit( void );
-void R_BrushShutdown( void );
 
 qboolean R_BrushModelLoad(struct model_s *mod, qboolean is_worldmodel);
 void R_BrushModelDestroyAll( void );

--- a/ref/vk/vk_buffer.h
+++ b/ref/vk/vk_buffer.h
@@ -1,9 +1,13 @@
 #pragma once
 
 #include "vk_core.h"
+#include "vk_module.h"
+
 #include "vk_devmem.h"
 #include "r_flipping.h"
 #include "alolcator.h"
+
+extern RVkModule g_module_buffer;
 
 typedef struct vk_buffer_s {
 	vk_devmem_t devmem;

--- a/ref/vk/vk_combuf.h
+++ b/ref/vk/vk_combuf.h
@@ -4,12 +4,11 @@
 
 #define MAX_GPU_SCOPES 64
 
+extern RVkModule g_module_combuf;
+
 typedef struct vk_combuf_s {
 	VkCommandBuffer cmdbuf;
 } vk_combuf_t;
-
-qboolean R_VkCombuf_Init( void );
-void R_VkCombuf_Destroy( void );
 
 vk_combuf_t* R_VkCombufOpen( void );
 void R_VkCombufClose( vk_combuf_t* );

--- a/ref/vk/vk_core.c
+++ b/ref/vk/vk_core.c
@@ -2,6 +2,7 @@
 
 #include "vk_common.h"
 #include "r_textures.h"
+#include "vk_textures.h"
 #include "vk_overlay.h"
 #include "vk_renderstate.h"
 #include "vk_staging.h"
@@ -691,6 +692,13 @@ static const r_vk_module_t *const modules[] = {
 	...
 };
 */
+
+// TODO(nilsoncore): Integrate all other modules.
+extern RVkModule g_module_textures;
+
+static const RVkModule *const g_modules[] = {
+	&g_module_textures
+};
 
 qboolean R_VkInit( void )
 {

--- a/ref/vk/vk_core.c
+++ b/ref/vk/vk_core.c
@@ -2,6 +2,7 @@
 
 #include "vk_common.h"
 #include "r_textures.h"
+#include "vk_textures.h"
 #include "vk_overlay.h"
 #include "vk_renderstate.h"
 #include "vk_staging.h"
@@ -705,6 +706,13 @@ static const r_vk_module_t *const modules[] = {
 	...
 };
 */
+
+// TODO(nilsoncore): Integrate all other modules.
+extern RVkModule g_module_textures;
+
+static const RVkModule *const g_modules[] = {
+	&g_module_textures
+};
 
 qboolean R_VkInit( void )
 {

--- a/ref/vk/vk_core.c
+++ b/ref/vk/vk_core.c
@@ -678,42 +678,6 @@ static qboolean initSurface( void )
 	return true;
 }
 
-// TODO modules
-/*
-typedef struct r_vk_module_s {
-	qboolean (*init)(void);
-	void (*destroy)(void);
-
-	// TODO next: dependecies, refcounts, ...
-} r_vk_module_t;
-
-#define LIST_MODULES(X) ...
-
-=>
-extern const r_vk_module_t vk_instance_module;
-...
-extern const r_vk_module_t vk_rtx_module;
-...
-
-=>
-static const r_vk_module_t *const modules[] = {
-	&vk_instance_module,
-	&vk_device_module,
-	&vk_aftermath_module,
-	&vk_texture_module,
-	...
-	&vk_rtx_module,
-	...
-};
-*/
-
-// TODO(nilsoncore): Integrate all other modules.
-extern RVkModule g_module_textures;
-
-static const RVkModule *const g_modules[] = {
-	&g_module_textures
-};
-
 qboolean R_VkInit( void )
 {
 	// FIXME !!!! handle initialization errors properly: destroy what has already been created
@@ -770,70 +734,67 @@ qboolean R_VkInit( void )
 		return false;
 	}
 
-#if USE_AFTERMATH
-	if (!VK_AftermathInit()) {
-		gEngine.Con_Printf( S_ERROR "Cannot initialize Nvidia Nsight Aftermath SDK\n" );
-	}
-#endif
-
 	if (!createDevice())
 		return false;
 
 	VK_LoadCvarsAfterInit();
 
-	if (!R_VkCombuf_Init())
-		return false;
-
 	if (!initSurface())
 		return false;
 
-	if (!VK_DevMemInit())
-		return false;
+	/* Print all modules with their dependencies (not printing states) */
 
-	if (!R_VkStagingInit())
-		return false;
+	RVkModule_PrintDependencyList( &g_module_combuf, false );
+	RVkModule_PrintDependencyList( &g_module_buffer, false );
+	RVkModule_PrintDependencyList( &g_module_devmem, false );
+	RVkModule_PrintDependencyList( &g_module_nv_aftermath, false );
+	RVkModule_PrintDependencyList( &g_module_staging, false );
+	RVkModule_PrintDependencyList( &g_module_image, false );
+	RVkModule_PrintDependencyList( &g_module_pipeline, false );
+	RVkModule_PrintDependencyList( &g_module_descriptor, false );
+	RVkModule_PrintDependencyList( &g_module_framectl, false );
+	RVkModule_PrintDependencyList( &g_module_geometry, false );
+	RVkModule_PrintDependencyList( &g_module_render, false );
+	RVkModule_PrintDependencyList( &g_module_studio, false );
+	RVkModule_PrintDependencyList( &g_module_scene, false );
+	RVkModule_PrintDependencyList( &g_module_textures_api, false );
+	RVkModule_PrintDependencyList( &g_module_textures, false );
+	RVkModule_PrintDependencyList( &g_module_overlay, false );
+	RVkModule_PrintDependencyList( &g_module_brush, false );
+	RVkModule_PrintDependencyList( &g_module_rtx, false );
+	RVkModule_PrintDependencyList( &g_module_light, false );
+	RVkModule_PrintDependencyList( &g_module_sprite, false );
+	RVkModule_PrintDependencyList( &g_module_beams, false );
 
-	if (!VK_PipelineInit())
-		return false;
+	/* Modules without dependencies */
 
-	// TODO ...
-	if (!VK_DescriptorInit())
-		return false;
+	if ( !g_module_combuf.Init() )  return false;
+	if ( !g_module_devmem.Init() )  return false;
+	if ( !g_module_descriptor.Init() )  return false;
+	if ( !g_module_nv_aftermath.Init() )  return false;
 
-	if (!VK_FrameCtlInit())
-		return false;
+	/* Modules with dependencies */
 
-	if (!R_GeometryBuffer_Init())
-		return false;
+	if ( !g_module_buffer.Init() )  return false;
+	if ( !g_module_staging.Init() )  return false;
+	if ( !g_module_image.Init() )  return false;
+	if ( !g_module_pipeline.Init() )  return false;
+	if ( !g_module_framectl.Init() )  return false;
+	if ( !g_module_geometry.Init() )  return false;
+	if ( !g_module_render.Init() )  return false;
+	if ( !g_module_studio.Init() )  return false;
+	if ( !g_module_scene.Init() )  return false;
+	if ( !g_module_textures_api.Init() )  return false; // +g_module_textures (hardcoded) -- @TexturesInitHardcode
+	if ( !g_module_overlay.Init() )  return false;
+	if ( !g_module_brush.Init() )  return false;
 
-	if (!VK_RenderInit())
-		return false;
-
-	VK_StudioInit();
-
-	VK_SceneInit();
-
-	R_TexturesInit();
-
-	// All below need render_pass
-
-	if (!R_VkOverlay_Init())
-		return false;
-
-	if (!R_BrushInit())
-		return false;
-
-	if (vk_core.rtx)
-	{
-		if (!VK_RayInit())
-			return false;
-
-		// FIXME move all this to rt-specific modules
-		VK_LightsInit();
+	if ( vk_core.rtx ) {
+		if ( !g_module_rtx.Init() )  return false;
+		if ( !g_module_light.Init() )  return false;
 	}
 
-	R_SpriteInit();
-	R_BeamInit();
+	if ( !g_module_sprite.Init() )  return false;
+	if ( !g_module_beams.Init() )  return false;
 
 	return true;
 }
@@ -843,42 +804,33 @@ void R_VkShutdown( void ) {
 
 	VK_EntityDataClear();
 
-	R_SpriteShutdown();
-
-	if (vk_core.rtx)
-	{
-		VK_LightsShutdown();
-		VK_RayShutdown();
+	g_module_beams.Shutdown();
+	g_module_sprite.Shutdown();
+	
+	if ( vk_core.rtx ) {
+		g_module_light.Shutdown();
+		g_module_rtx.Shutdown();
 	}
 
-	R_BrushShutdown();
-	VK_StudioShutdown();
-	R_VkOverlay_Shutdown();
+	g_module_brush.Shutdown();
+	g_module_overlay.Shutdown();
+	g_module_textures_api.Shutdown();
+	g_module_textures.Shutdown();
+	g_module_scene.Shutdown();
+	g_module_studio.Shutdown();
+	g_module_render.Shutdown();
+	g_module_geometry.Shutdown();
+	g_module_framectl.Shutdown();
+	g_module_pipeline.Shutdown();
+	g_module_staging.Shutdown();
+	g_module_buffer.Shutdown();
 
-	VK_RenderShutdown();
-	R_GeometryBuffer_Shutdown();
-
-	VK_FrameCtlShutdown();
-
-	R_VkMaterialsShutdown();
-
-	R_TexturesShutdown();
-
-	VK_PipelineShutdown();
-
-	VK_DescriptorShutdown();
-
-	R_VkStagingShutdown();
-
-	R_VkCombuf_Destroy();
-
-	VK_DevMemDestroy();
+	g_module_nv_aftermath.Shutdown();
+	g_module_descriptor.Shutdown();
+	g_module_devmem.Shutdown();
+	g_module_combuf.Shutdown();
 
 	vkDestroyDevice(vk_core.device, NULL);
-
-#if USE_AFTERMATH
-	VK_AftermathShutdown();
-#endif
 
 	if (vk_core.debug_messenger)
 	{

--- a/ref/vk/vk_descriptor.c
+++ b/ref/vk/vk_descriptor.c
@@ -2,110 +2,18 @@
 
 #include "eiface.h" // ARRAYSIZE
 
+static qboolean Impl_Init( void );
+static     void Impl_Shutdown( void );
+
+RVkModule g_module_descriptor = {
+	.name = "descriptor",
+	.state = RVkModuleState_NotInitialized,
+	.dependencies = RVkModuleDependencies_Empty,
+	.Init = Impl_Init,
+	.Shutdown = Impl_Shutdown
+};
+
 descriptor_pool_t vk_desc_fixme;
-
-qboolean VK_DescriptorInit( void )
-{
-	int max_desc_sets = 0;
-
-	VkDescriptorPoolSize dps[] = {
-		{
-			.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-			.descriptorCount = MAX_TEXTURES,
-		}, {
-			.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
-			.descriptorCount = ARRAYSIZE(vk_desc_fixme.ubo_sets),
-		/*
-		}, {
-			.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-			.descriptorCount = 1,
-		*/
-		},
-	};
-	VkDescriptorPoolCreateInfo dpci = {
-		.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
-		.pPoolSizes = dps,
-		.poolSizeCount = ARRAYSIZE(dps),
-	};
-
-	for (int i = 0; i < ARRAYSIZE(dps); ++i)
-		max_desc_sets += dps[i].descriptorCount;
-
-	dpci.maxSets = max_desc_sets;
-
-	XVK_CHECK(vkCreateDescriptorPool(vk_core.device, &dpci, NULL, &vk_desc_fixme.pool));
-
-	{
-		const int num_sets = MAX_TEXTURES;
-		// ... TODO find better place for this; this should be per-pipeline/shader
-		const VkDescriptorSetLayoutBinding bindings[] = { {
-			.binding = 0,
-			.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-			.descriptorCount = 1,
-			.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT,
-			.pImmutableSamplers = NULL,
-		}};
-		const VkDescriptorSetLayoutCreateInfo dslci = {
-			.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
-			.bindingCount = ARRAYSIZE(bindings),
-			.pBindings = bindings,
-		};
-		VkDescriptorSetLayout* tmp_layouts = Mem_Malloc(vk_core.pool, sizeof(VkDescriptorSetLayout) * num_sets);
-		const VkDescriptorSetAllocateInfo dsai = {
-			.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
-			.descriptorPool = vk_desc_fixme.pool,
-			.descriptorSetCount = num_sets,
-			.pSetLayouts = tmp_layouts,
-		};
-		XVK_CHECK(vkCreateDescriptorSetLayout(vk_core.device, &dslci, NULL, &vk_desc_fixme.one_texture_layout));
-		for (int i = 0; i < num_sets; ++i)
-			tmp_layouts[i] = vk_desc_fixme.one_texture_layout;
-
-		XVK_CHECK(vkAllocateDescriptorSets(vk_core.device, &dsai, vk_desc_fixme.texture_sets));
-
-		Mem_Free(tmp_layouts);
-	}
-
-	{
-		const int num_sets = ARRAYSIZE(vk_desc_fixme.ubo_sets);
-		// ... TODO find better place for this; this should be per-pipeline/shader
-		VkDescriptorSetLayoutBinding bindings[] = { {
-				.binding = 0,
-				.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
-				.descriptorCount = 1,
-				// TODO we use these sets for both vertex-only and fragment-only bindings; improve
-				.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
-		}};
-		VkDescriptorSetLayoutCreateInfo dslci = {
-			.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
-			.bindingCount = ARRAYSIZE(bindings),
-			.pBindings = bindings,
-		};
-		VkDescriptorSetLayout* tmp_layouts = Mem_Malloc(vk_core.pool, sizeof(VkDescriptorSetLayout) * num_sets);
-		VkDescriptorSetAllocateInfo dsai = {
-			.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
-			.descriptorPool = vk_desc_fixme.pool,
-			.descriptorSetCount = num_sets,
-			.pSetLayouts = tmp_layouts,
-		};
-		XVK_CHECK(vkCreateDescriptorSetLayout(vk_core.device, &dslci, NULL, &vk_desc_fixme.one_uniform_buffer_layout));
-		for (int i = 0; i < num_sets; ++i)
-				tmp_layouts[i] = vk_desc_fixme.one_uniform_buffer_layout;
-
-		XVK_CHECK(vkAllocateDescriptorSets(vk_core.device, &dsai, vk_desc_fixme.ubo_sets));
-
-		Mem_Free(tmp_layouts);
-	}
-
-	return true;
-}
-
-void VK_DescriptorShutdown( void )
-{
-	vkDestroyDescriptorPool(vk_core.device, vk_desc_fixme.pool, NULL);
-	vkDestroyDescriptorSetLayout(vk_core.device, vk_desc_fixme.one_texture_layout, NULL);
-	vkDestroyDescriptorSetLayout(vk_core.device, vk_desc_fixme.one_uniform_buffer_layout, NULL);
-}
 
 void VK_DescriptorsCreate(vk_descriptors_t *desc)
 {
@@ -219,4 +127,112 @@ void VK_DescriptorsDestroy(const vk_descriptors_t *desc)
 	vkDestroyDescriptorPool(vk_core.device, desc->desc_pool, NULL);
 	vkDestroyPipelineLayout(vk_core.device, desc->pipeline_layout, NULL);
 	vkDestroyDescriptorSetLayout(vk_core.device, desc->desc_layout, NULL);
+}
+
+static qboolean Impl_Init( void ) {
+	XRVkModule_OnInitStart( g_module_descriptor );
+
+	int max_desc_sets = 0;
+
+	VkDescriptorPoolSize dps[] = {
+		{
+			.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+			.descriptorCount = MAX_TEXTURES,
+		}, {
+			.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
+			.descriptorCount = ARRAYSIZE(vk_desc_fixme.ubo_sets),
+		/*
+		}, {
+			.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+			.descriptorCount = 1,
+		*/
+		},
+	};
+	VkDescriptorPoolCreateInfo dpci = {
+		.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+		.pPoolSizes = dps,
+		.poolSizeCount = ARRAYSIZE(dps),
+	};
+
+	for (int i = 0; i < ARRAYSIZE(dps); ++i)
+		max_desc_sets += dps[i].descriptorCount;
+
+	dpci.maxSets = max_desc_sets;
+
+	XVK_CHECK(vkCreateDescriptorPool(vk_core.device, &dpci, NULL, &vk_desc_fixme.pool));
+
+	{
+		const int num_sets = MAX_TEXTURES;
+		// ... TODO find better place for this; this should be per-pipeline/shader
+		const VkDescriptorSetLayoutBinding bindings[] = { {
+			.binding = 0,
+			.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+			.descriptorCount = 1,
+			.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT,
+			.pImmutableSamplers = NULL,
+		}};
+		const VkDescriptorSetLayoutCreateInfo dslci = {
+			.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
+			.bindingCount = ARRAYSIZE(bindings),
+			.pBindings = bindings,
+		};
+		VkDescriptorSetLayout* tmp_layouts = Mem_Malloc(vk_core.pool, sizeof(VkDescriptorSetLayout) * num_sets);
+		const VkDescriptorSetAllocateInfo dsai = {
+			.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
+			.descriptorPool = vk_desc_fixme.pool,
+			.descriptorSetCount = num_sets,
+			.pSetLayouts = tmp_layouts,
+		};
+		XVK_CHECK(vkCreateDescriptorSetLayout(vk_core.device, &dslci, NULL, &vk_desc_fixme.one_texture_layout));
+		for (int i = 0; i < num_sets; ++i)
+			tmp_layouts[i] = vk_desc_fixme.one_texture_layout;
+
+		XVK_CHECK(vkAllocateDescriptorSets(vk_core.device, &dsai, vk_desc_fixme.texture_sets));
+
+		Mem_Free(tmp_layouts);
+	}
+
+	{
+		const int num_sets = ARRAYSIZE(vk_desc_fixme.ubo_sets);
+		// ... TODO find better place for this; this should be per-pipeline/shader
+		VkDescriptorSetLayoutBinding bindings[] = { {
+				.binding = 0,
+				.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
+				.descriptorCount = 1,
+				// TODO we use these sets for both vertex-only and fragment-only bindings; improve
+				.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
+		}};
+		VkDescriptorSetLayoutCreateInfo dslci = {
+			.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
+			.bindingCount = ARRAYSIZE(bindings),
+			.pBindings = bindings,
+		};
+		VkDescriptorSetLayout* tmp_layouts = Mem_Malloc(vk_core.pool, sizeof(VkDescriptorSetLayout) * num_sets);
+		VkDescriptorSetAllocateInfo dsai = {
+			.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
+			.descriptorPool = vk_desc_fixme.pool,
+			.descriptorSetCount = num_sets,
+			.pSetLayouts = tmp_layouts,
+		};
+		XVK_CHECK(vkCreateDescriptorSetLayout(vk_core.device, &dslci, NULL, &vk_desc_fixme.one_uniform_buffer_layout));
+		for (int i = 0; i < num_sets; ++i)
+				tmp_layouts[i] = vk_desc_fixme.one_uniform_buffer_layout;
+
+		XVK_CHECK(vkAllocateDescriptorSets(vk_core.device, &dsai, vk_desc_fixme.ubo_sets));
+
+		Mem_Free(tmp_layouts);
+	}
+
+	XRVkModule_OnInitEnd( g_module_descriptor );
+	return true;
+}
+
+static void Impl_Shutdown( void ) {
+	XRVkModule_OnShutdownStart( g_module_descriptor );
+
+	vkDestroyDescriptorPool(vk_core.device, vk_desc_fixme.pool, NULL);
+	vkDestroyDescriptorSetLayout(vk_core.device, vk_desc_fixme.one_texture_layout, NULL);
+	vkDestroyDescriptorSetLayout(vk_core.device, vk_desc_fixme.one_uniform_buffer_layout, NULL);
+
+	XRVkModule_OnShutdownEnd( g_module_descriptor );
 }

--- a/ref/vk/vk_descriptor.h
+++ b/ref/vk/vk_descriptor.h
@@ -1,8 +1,11 @@
 #pragma once
 
 #include "vk_core.h"
+#include "vk_module.h"
 
 #include "vk_const.h"
+
+extern RVkModule g_module_descriptor;
 
 // Only used for traditional renderer
 typedef struct descriptor_pool_s
@@ -19,9 +22,6 @@ typedef struct descriptor_pool_s
 
 // FIXME: move to traditional renderer
 extern descriptor_pool_t vk_desc_fixme;
-
-qboolean VK_DescriptorInit( void );
-void VK_DescriptorShutdown( void );
 
 struct xvk_image_s;
 typedef union {

--- a/ref/vk/vk_devmem.h
+++ b/ref/vk/vk_devmem.h
@@ -1,8 +1,9 @@
 #pragma once
-#include "vk_core.h"
 
-qboolean VK_DevMemInit( void );
-void VK_DevMemDestroy( void );
+#include "vk_core.h"
+#include "vk_module.h"
+
+extern RVkModule g_module_devmem;
 
 typedef struct vk_devmem_s {
 	VkDeviceMemory device_memory;

--- a/ref/vk/vk_framectl.h
+++ b/ref/vk/vk_framectl.h
@@ -1,9 +1,13 @@
 #pragma once
+
 #include "vk_core.h"
+#include "vk_module.h"
 
 #include "xash3d_types.h"
 
 #define MAX_CONCURRENT_FRAMES 2
+
+extern RVkModule g_module_framectl;
 
 // TODO most of the things below should not be global. Instead, they should be passed as an argument/context to all the drawing functions that want this info
 typedef struct vk_framectl_s {
@@ -25,9 +29,6 @@ typedef struct vk_framectl_s {
 } vk_framectl_t;
 
 extern vk_framectl_t vk_frame;
-
-qboolean VK_FrameCtlInit( void );
-void VK_FrameCtlShutdown( void );
 
 void R_BeginFrame( qboolean clearScene );
 void VK_RenderFrame( const struct ref_viewpass_s *rvp );

--- a/ref/vk/vk_geometry.h
+++ b/ref/vk/vk_geometry.h
@@ -1,9 +1,14 @@
 #pragma once
+
+#include "vk_core.h"
+#include "vk_module.h"
+
 #include "vk_common.h"
 #include "r_block.h"
-#include "vk_core.h"
 
 #include <stdint.h>
+
+extern RVkModule g_module_geometry;
 
 // General buffer usage pattern
 // 1. alloc (allocates buffer mem, stores allocation data)
@@ -82,9 +87,6 @@ qboolean R_GeometryBufferAllocOnceAndLock(r_geometry_buffer_lock_t *lock, int ve
 void R_GeometryBufferUnlock( const r_geometry_buffer_lock_t *lock );
 
 void R_GeometryBuffer_MapClear( void ); // Free the entire buffer for a new map
-
-qboolean R_GeometryBuffer_Init(void);
-void R_GeometryBuffer_Shutdown(void);
 
 void R_GeometryBuffer_Flip(void);
 

--- a/ref/vk/vk_image.c
+++ b/ref/vk/vk_image.c
@@ -8,6 +8,28 @@
 // Long type lists functions
 #include "vk_image_extra.h"
 
+static qboolean Impl_Init( void );
+static     void Impl_Shutdown( void );
+
+static RVkModule *required_modules[] = {
+	// R_VkImageCreate: VK_DevMemAllocate
+	// R_VkImageDestroy: VK_DevMemFree
+	&g_module_devmem,
+
+	// R_VkImageUploadBegin: R_VkStagingGetCommandBuffer
+	// R_VkImageUploadSlice: R_VkStagingLockForImage, R_VkStagingUnlock
+	// R_VkImageUploadEnd: R_VkStagingCommit
+	&g_module_staging
+};
+
+RVkModule g_module_image = {
+	.name = "image",
+	.state = RVkModuleState_NotInitialized,
+	.dependencies = RVkModuleDependencies_FromStaticArray( required_modules ),
+	.Init = Impl_Init,
+	.Shutdown = Impl_Shutdown
+};
+
 static const VkImageUsageFlags usage_bits_implying_views =
 	VK_IMAGE_USAGE_SAMPLED_BIT |
 	VK_IMAGE_USAGE_STORAGE_BIT |
@@ -320,4 +342,21 @@ void R_VkImageUploadEnd( r_vk_image_t *img ) {
 			// FIXME incorrect, we also use them in compute and potentially ray tracing shaders
 			VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
 			0, 0, NULL, 0, NULL, 1, &image_barrier);
+}
+
+static qboolean Impl_Init( void ) {
+	XRVkModule_OnInitStart( g_module_image );
+
+	// Nothing to init for now.
+
+	XRVkModule_OnInitEnd( g_module_image );
+	return true;
+}
+
+static void Impl_Shutdown( void ) {
+	XRVkModule_OnShutdownStart( g_module_image );
+
+	// Nothing to clear for now.
+
+	XRVkModule_OnShutdownEnd( g_module_image );
 }

--- a/ref/vk/vk_image.h
+++ b/ref/vk/vk_image.h
@@ -1,6 +1,11 @@
 #pragma once
+
 #include "vk_core.h"
+#include "vk_module.h"
+
 #include "vk_devmem.h"
+
+extern RVkModule g_module_image;
 
 typedef struct r_vk_image_s {
 	vk_devmem_t devmem;

--- a/ref/vk/vk_light.h
+++ b/ref/vk/vk_light.h
@@ -2,8 +2,11 @@
 
 #include "vk_const.h"
 #include "vk_core.h"
+#include "vk_module.h"
 
 #include "xash3d_types.h"
+
+extern RVkModule g_module_light;
 
 typedef struct {
 	uint8_t num_point_lights;
@@ -62,9 +65,6 @@ typedef struct {
 } vk_lights_t;
 
 extern vk_lights_t g_lights;
-
-qboolean VK_LightsInit( void );
-void VK_LightsShutdown( void );
 
 // Allocate clusters and vis data for the new map
 struct model_s;

--- a/ref/vk/vk_materials.c
+++ b/ref/vk/vk_materials.c
@@ -15,6 +15,28 @@
 #define MAX_MATERIALS 2048
 #define MAX_NEW_MATERIALS 128
 
+static qboolean Impl_Init( void );
+static     void Impl_Shutdown( void );
+
+static RVkModule *required_modules[] = {
+	// loadTexture: R_TextureUploadFromFileExAcquire
+	// acquireTexturesForMaterial: R_TextureAcquire
+	// releaseTexturesForMaterialPtr: R_TextureRelease
+	// assignMaterialForTexture: R_TextureGetNameByIndex
+	// loadMaterialsFromFile: R_TextureAcquire, R_TextureGetNameByIndex
+	// R_VkMaterialGetForTextureWithFlags: R_TextureGetNameByIndex
+	// R_VkMaterialGetForName: R_TextureFindByNameLike
+	&g_module_textures_api
+};
+
+RVkModule g_module_materials = {
+	.name = "materials",
+	.state = RVkModuleState_NotInitialized,
+	.dependencies = RVkModuleDependencies_FromStaticArray( required_modules ),
+	.Init = Impl_Init,
+	.Shutdown = Impl_Shutdown
+};
+
 static r_vk_material_t k_default_material = {
 	.tex_base_color = -1,
 	.tex_metalness = 0,
@@ -634,7 +656,19 @@ qboolean R_VkMaterialGetEx( int tex_id, int rendermode, r_vk_material_t *out_mat
 	return false;
 }
 
-void R_VkMaterialsShutdown( void ) {
-	materialsReleaseTextures();
+static qboolean Impl_Init( void ) {
+	XRVkModule_OnInitStart( g_module_materials );
+
+	// Nothing to init for now.
+
+	XRVkModule_OnInitEnd( g_module_materials );
+	return true;
 }
 
+static void Impl_Shutdown( void ) {
+	XRVkModule_OnShutdownStart( g_module_materials );
+
+	materialsReleaseTextures();
+
+	XRVkModule_OnShutdownEnd( g_module_materials );
+}

--- a/ref/vk/vk_materials.h
+++ b/ref/vk/vk_materials.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include "vk_module.h"
+
 #include "xash3d_types.h"
+
+extern RVkModule g_module_materials;
 
 /* TODO
 #define MATERIAL_FIELDS_LIST(X) \
@@ -33,8 +37,6 @@ typedef struct { int index; } r_vk_material_ref_t;
 // Note: invalidates all previously issued material refs
 // TODO: track "version" in high bits?
 void R_VkMaterialsReload( void );
-
-void R_VkMaterialsShutdown( void );
 
 struct model_s;
 void R_VkMaterialsLoadForModel( const struct model_s* mod );

--- a/ref/vk/vk_module.c
+++ b/ref/vk/vk_module.c
@@ -1,0 +1,92 @@
+#include "vk_module.h"
+
+uint32_t RVkModule_InitAll( RVkModule* modules, uint32_t count ) {
+	uint32_t module_index = 0;
+	while ( module_index < count ) {
+		RVkModule *const module = &modules[module_index];
+		if ( !RVkModule_IsPreInitialized( module ) )
+			break;
+
+		if ( module->Init( RVkModuleLogLevels_All, RVkModuleArgs_Empty ) != RVkModuleResult_Success ) {
+			module->Shutdown();
+			break;
+		}
+
+		module_index += 1;
+	}
+
+	qboolean all_modules_inited = ( module_index == count );
+	if ( !all_modules_inited ) {
+		int32_t last_inited_module_index = module_index - 1;
+		while ( last_inited_module_index >= 0 ) {
+			RVkModule *const module = &modules[last_inited_module_index];
+			module->Shutdown();
+		}
+	}
+
+	return module_index;
+}
+
+const char *RVkModule_GetStateName( RVkModuleState state ) {
+	switch ( state ) {
+		case RVkModuleState_None:               return "None";
+		case RVkModuleState_PreInitialized:     return "PreInitialized";
+		case RVkModuleState_Initialized:        return "Initialize";
+		case RVkModuleState_FailedToInitialize: return "FailedToInitialize";
+		case RVkModuleState_ManualShutdown:     return "ManualShutdown";
+		case RVkModuleState_ForcedShutdown:     return "ForcedShutdown";
+		default:                                return "(invalid)";
+	}
+}
+
+RVkModuleNameHash RVkModule_GetNameHash( const char *name ) {
+	// TODO(nilsoncore): FIXME(nilsoncore): Implement real hashing function.
+	// Quick hack for now:
+	static RVkModuleNameHash g_module_counter = 0;
+	return g_module_counter++;
+}
+
+qboolean RVkModule_IsPreInitialized( RVkModule *module ) {
+	// TODO(nilsoncore): Also make sure it is null-terminated, not empty, etc.
+	// This would probably require some other headers with functions
+	// like `Q_strlen` and others.
+	// ---
+	// Check that the name is set.
+	if ( !module->name )
+		return false;
+
+	// Check that the pointer to internal module data is set. 
+	if ( !module->data )
+		return false;
+
+	// Check that the state is set properly.
+	if ( module->state != RVkModuleState_PreInitialized)
+		return false;
+
+	// Check that all the function pointers are at least pointing somewhere
+	// (we cannot staticly check that they are pointing to real functions).
+	if ( !module->Init )
+		return false;
+
+	if ( !module->GetResultName )
+		return false;
+
+	if ( !module->Shutdown )
+		return false;
+
+	return true;
+}
+
+qboolean RVkModule_IsInitialized( RVkModule *module ) {
+	// Check that the state is set properly.
+	if ( module->state != RVkModuleState_Initialized )
+		return false;
+	
+	// Check that the name's hash has at least some non-zero value
+	// (we cannot check whether the value is `valid`
+	// since hashing function should be unpredictable).
+	if ( module->hash == 0 )
+		return false;
+
+	return true;
+}

--- a/ref/vk/vk_module.c
+++ b/ref/vk/vk_module.c
@@ -1,92 +1,149 @@
 #include "vk_module.h"
+#include "debugbreak.h"
 
-uint32_t RVkModule_InitAll( RVkModule* modules, uint32_t count ) {
-	uint32_t module_index = 0;
-	while ( module_index < count ) {
-		RVkModule *const module = &modules[module_index];
-		if ( !RVkModule_IsPreInitialized( module ) )
-			break;
+// NOTE(nilsoncore):
+// These `replica` functions are broken for now because I didn't update them to be exact as `XRVkModule_Onxxx` macros.
+// The reason why these functions exist (for now) is that I don't know whether we should use macros or functions like these.
+// For now we just wrap around every `Impl_Init` module function with `XRVkModule_OnxxxStart` and `XRVkModule_OnxxxEnd`.
+// 
+// This approach is quite simple and clean: you just write this construction passing it module and that's it.
+// You don't have to do anything else and know how it works inside (for the most part).
+// Although, it has a downside: these macros are CHUNKY. We don't just call some function, we paste the whole code inline
+// for every module out there.  It probably grows the binary size a lot (didn't measure).
+// 
+// The second approach is to use regular functions.  It is probably more conventional and rational way, but it has downsides too.
+// You can't just write it and expect it to work.  The placing is the same as with the macros, but things start to become tricky.
+// We can't use `qboolean` as a result value because of the `already initialized?` check.
+// If module is already initialized we return `true` from the module `Impl_Init` function.  Here inside `OnInitStart` it's too ambigious -
+// does that mean that module is already initialized and we are done or module has loaded dependencies and ready to initialize?
+// In this case we should probably declare some enum with states like `_AlreadyInitialized`, `_DependenciesLoaded`, `_FailedToLoadDependecies`, etc.
+// In the end we will end up not just with the boilerplate code that we have to paste everywhere, but also we can't make change in one place --
+// every change must be then made manually in every file.
+// 
+// Whether we want it or not -- we must decide which approach we will use. Don't be afraid to comment on this if I missed something.
 
-		if ( module->Init( RVkModuleLogLevels_All, RVkModuleArgs_Empty ) != RVkModuleResult_Success ) {
-			module->Shutdown( true );
-			break;
-		}
+qboolean RVkModule_OnInitStart( RVkModule *module ) {
+	if ( module->state == RVkModuleState_Initialized )
+		return true;
 
-		module_index += 1;
+	gEngine.Con_Printf( "RVkModule: Initializing '%s'...\n", module->name );
+	module->state = RVkModuleState_IsInitializing;
+	
+	qboolean deps_inited = RVkModule_InitDependencies( module );
+	if ( !deps_inited ) {
+		module->state = RVkModuleState_NotInitialized;
+		return false;
 	}
 
-	qboolean all_modules_inited = ( module_index == count );
-	if ( !all_modules_inited ) {
-		int32_t last_inited_module_index = module_index - 1;
-		while ( last_inited_module_index >= 0 ) {
-			RVkModule *const module = &modules[last_inited_module_index];
-			module->Shutdown( true );
+	return true;
+}
+
+void RVkModule_OnInitEnd( RVkModule *module ) {
+	module->state = RVkModuleState_Initialized;
+	gEngine.Con_Printf( "RVkModule: '%s' has been initialized.\n", module->name );
+}
+
+qboolean RVkModule_OnShutdownStart( RVkModule *module ) {
+	if ( module->state != RVkModuleState_Initialized )
+		return false;
+
+	gEngine.Con_Printf( "RVkModule: Shutting down '%s'...\n", module->name );
+	return true;
+}
+
+void RVkModule_OnShutdownEnd( RVkModule *module ) {
+	module->state = RVkModuleState_Shutdown;
+	gEngine.Con_Printf( "RVkModule: '%s' has been shut down.\n", module->name );
+}
+
+qboolean RVkModule_InitDependencies( RVkModule *module ) {
+	ASSERT( module && "Module pointer must be valid" );
+
+	const uint32_t deps_count = module->dependencies.count;
+	qboolean second_try = false;
+	uint32_t deps_in_progress_count = 0;
+
+init_dependencies:
+	for ( uint32_t dep_module_index = 0; dep_module_index < deps_count; dep_module_index += 1 ) {
+		RVkModule *const dep_module = module->dependencies.modules[dep_module_index];
+
+		if ( dep_module == module ) {
+			gEngine.Host_Error( "RVkModule: Failed to load dependencies for '%s' - module depends on itself.\n", module->name );
+			debug_break();
+		}
+
+		if ( dep_module->state == RVkModuleState_IsInitializing ) {
+			if ( second_try ) {
+				RVkModule_PrintDependencyList( module, true );
+				RVkModule_PrintDependencyList( dep_module, true );
+				gEngine.Host_Error( "RVkModule: Failed to load dependencies for '%s' - module is stuck on '%s' (it is a circular dependency chain).\n", module->name, dep_module->name );
+				debug_break();
+			} else {
+				deps_in_progress_count += 1;
+				continue;
+			}
+		} 
+
+		if ( dep_module->init_caller == NULL ) {
+			if ( dep_module->state != RVkModuleState_Initialized || dep_module->state != RVkModuleState_IsInitializing ) {
+				dep_module->init_caller = module;
+			} else {
+				gEngine.Con_Printf( S_WARN "Module '%s' is initializing '%s' but init caller is already set: '%s'.\n", module->name, dep_module->name, dep_module->init_caller->name );
+			}
+		}
+
+		if ( !dep_module->Init() ) {
+			gEngine.Con_Printf( S_ERROR "Module '%s' failed to load dependency '%s'.\n", module->name, dep_module->name );
+			return false;
 		}
 	}
 
-	return module_index;
+	second_try = ( deps_in_progress_count > 0 );
+	if ( second_try )
+		goto init_dependencies;
+	
+	return true;
+}
+
+void RVkModule_PrintDependencyList( RVkModule *module, qboolean print_states ) {
+	ASSERT( module && "Module pointer must be valid" );
+
+	const uint32_t deps_count = module->dependencies.count;
+	if ( deps_count == 0 ) {
+		gEngine.Con_Printf( "Module '%s' has 0 dependencies.\n", module->name );
+	} else {
+		gEngine.Con_Printf( "Module '%s' has %u dependenc%s: [", module->name, deps_count, ( deps_count == 1 ) ? "y" : "ies" );
+
+		// #0
+		uint32_t dep_module_index = 0;
+		RVkModule *const dep_module = module->dependencies.modules[dep_module_index];
+		if ( print_states )  gEngine.Con_Printf( "%s (%s)", dep_module->name, RVkModule_GetStateName( dep_module->state ) );
+		else                 gEngine.Con_Printf( "%s", dep_module->name );
+
+		// #1..deps_count
+		for ( dep_module_index = 1; dep_module_index < deps_count; dep_module_index += 1 ) {
+			RVkModule *const dep_module = module->dependencies.modules[dep_module_index];
+			if ( print_states )  gEngine.Con_Printf( ", %s (%s)", dep_module->name, RVkModule_GetStateName( dep_module->state ) );
+			else                 gEngine.Con_Printf( ", %s", dep_module->name );
+		}
+	
+		gEngine.Con_Printf( "]\n" );
+	}
+}
+
+void RVkModule_PrintDependencyTree( RVkModule *module ) {
+	ASSERT( module && "Module pointer must be valid" );
+
+	gEngine.Con_Printf( "Dependency tree of module '%s':\n", module->name );
+	// TODO(nilsoncore)
 }
 
 const char *RVkModule_GetStateName( RVkModuleState state ) {
 	switch ( state ) {
-		case RVkModuleState_None:               return "None";
-		case RVkModuleState_PreInitialized:     return "PreInitialized";
-		case RVkModuleState_Initialized:        return "Initialize";
-		case RVkModuleState_FailedToInitialize: return "FailedToInitialize";
-		case RVkModuleState_ManualShutdown:     return "ManualShutdown";
-		case RVkModuleState_ForcedShutdown:     return "ForcedShutdown";
-		default:                                return "(invalid)";
+		case RVkModuleState_NotInitialized:  return "NotInitialized";
+		case RVkModuleState_IsInitializing:  return "IsInitializing";
+		case RVkModuleState_Initialized:     return "Initialized";
+		case RVkModuleState_Shutdown:        return "Shutdown";
+		default:                             return "(invalid)";
 	}
-}
-
-RVkModuleNameHash RVkModule_GetNameHash( const char *name ) {
-	// TODO(nilsoncore): FIXME(nilsoncore): Implement real hashing function.
-	// Quick hack for now:
-	static RVkModuleNameHash g_module_counter = 0;
-	return g_module_counter++;
-}
-
-qboolean RVkModule_IsPreInitialized( RVkModule *module ) {
-	// TODO(nilsoncore): Also make sure it is null-terminated, not empty, etc.
-	// This would probably require some other headers with functions
-	// like `Q_strlen` and others.
-	// ---
-	// Check that the name is set.
-	if ( !module->name )
-		return false;
-
-	// Check that the pointer to internal module data is set. 
-	if ( !module->data )
-		return false;
-
-	// Check that the state is set properly.
-	if ( module->state != RVkModuleState_PreInitialized)
-		return false;
-
-	// Check that all the function pointers are at least pointing somewhere
-	// (we cannot staticly check that they are pointing to real functions).
-	if ( !module->Init )
-		return false;
-
-	if ( !module->GetResultName )
-		return false;
-
-	if ( !module->Shutdown )
-		return false;
-
-	return true;
-}
-
-qboolean RVkModule_IsInitialized( RVkModule *module ) {
-	// Check that the state is set properly.
-	if ( module->state != RVkModuleState_Initialized )
-		return false;
-	
-	// Check that the name's hash has at least some non-zero value
-	// (we cannot check whether the value is `valid`
-	// since hashing function should be unpredictable).
-	if ( module->hash == 0 )
-		return false;
-
-	return true;
 }

--- a/ref/vk/vk_module.c
+++ b/ref/vk/vk_module.c
@@ -8,7 +8,7 @@ uint32_t RVkModule_InitAll( RVkModule* modules, uint32_t count ) {
 			break;
 
 		if ( module->Init( RVkModuleLogLevels_All, RVkModuleArgs_Empty ) != RVkModuleResult_Success ) {
-			module->Shutdown();
+			module->Shutdown( true );
 			break;
 		}
 
@@ -20,7 +20,7 @@ uint32_t RVkModule_InitAll( RVkModule* modules, uint32_t count ) {
 		int32_t last_inited_module_index = module_index - 1;
 		while ( last_inited_module_index >= 0 ) {
 			RVkModule *const module = &modules[last_inited_module_index];
-			module->Shutdown();
+			module->Shutdown( true );
 		}
 	}
 

--- a/ref/vk/vk_module.h
+++ b/ref/vk/vk_module.h
@@ -1,0 +1,97 @@
+/*
+	vk_module.h - ref/vk modules' API
+
+	TODO(nilsoncore): Explain what this is.
+*/
+
+#pragma once
+#ifndef VK_MODULE_H
+#define VK_MODULE_H
+
+#include "vk_core.h"
+
+typedef enum {
+	RVkModuleResult_Success = 0
+} RVkModuleResult;
+
+typedef uint8_t RVkModuleState;
+enum {
+	RVkModuleState_None               = 0,
+	RVkModuleState_PreInitialized     = 1,
+	RVkModuleState_Initialized        = 2,
+	RVkModuleState_FailedToInitialize = 3,
+	RVkModuleState_ManualShutdown     = 4,
+	RVkModuleState_ForcedShutdown     = 5,
+
+	RVkModuleState_COUNT
+};
+
+typedef uint8_t RVkModuleLogLevels;
+enum {
+	RVkModuleLogLevels_None    = 0,
+	RVkModuleLogLevels_Error   = (1 << 0),
+	RVkModuleLogLevels_Warning = (1 << 1),
+	RVkModuleLogLevels_Info    = (1 << 2),
+	RVkModuleLogLevels_Debug   = (1 << 3),
+
+	// Shortcuts:
+	RVkModuleLogLevels_AllExceptDebug = RVkModuleLogLevels_Error   |
+	                                    RVkModuleLogLevels_Warning |
+	                                    RVkModuleLogLevels_Info,
+	
+	RVkModuleLogLevels_All = RVkModuleLogLevels_AllExceptDebug |
+	                         RVkModuleLogLevels_Debug
+};
+
+// Forward declare it so we can use it right below before we actually declare its' body.
+typedef struct RVkModule RVkModule; 
+
+typedef struct RVkModuleDependencies {
+	const char **required_module_names;
+	struct RVkModule *modules;
+	uint32_t count;
+} RVkModuleDependencies;
+
+typedef struct RVkModuleArgs {
+	char **args;
+	uint32_t count;
+} RVkModuleArgs;
+
+// Shortcut to inline-create empty argument list.
+// Usage:  module.Init( log_levels, RVkModuleArgs_Empty );
+#define RVkModuleArgs_Empty ( RVkModuleArgs ){ .args = NULL, .count = 0 }
+
+typedef uint64_t RVkModuleNameHash;
+
+typedef RVkModuleResult ( *RVkModulePfn_Init )( RVkModuleLogLevels /*log_levels*/, RVkModuleArgs /*args*/ );
+typedef    const char * ( *RVkModulePfn_GetResultName )( RVkModuleResult /*result*/ );
+typedef            void ( *RVkModulePfn_Shutdown )( void );
+
+typedef struct RVkModule {
+	// `PreInitialization`-filled fields.
+	// These fields are should be set in `vk_xxx.c` files by declaring global variable `g_module_xxx`
+	// and manually setting proper values and function pointers.
+	const char *name;
+	void *data;
+	RVkModuleState state;
+
+	RVkModuleDependencies dependencies;
+	uint32_t reference_count;
+
+	RVkModulePfn_Init          Init;
+	RVkModulePfn_GetResultName GetResultName;
+	RVkModulePfn_Shutdown      Shutdown;
+
+	// `Initialization`-filled fields.
+	// These fields are should be set after successful `Init` function completion.
+	RVkModuleNameHash hash;
+	RVkModuleLogLevels log_levels;
+} RVkModule;
+
+uint32_t RVkModule_InitAll( RVkModule* modules, uint32_t count );
+const char *RVkModule_GetStateName( RVkModuleState state );
+RVkModuleNameHash RVkModule_GetNameHash( const char *name ); // Not implemented yet. (stub)
+qboolean RVkModule_IsPreInitialized( RVkModule *module );
+qboolean RVkModule_IsInitialized( RVkModule *module );
+
+#endif /* VK_MODULE_H */

--- a/ref/vk/vk_module.h
+++ b/ref/vk/vk_module.h
@@ -8,24 +8,19 @@
 #ifndef VK_MODULE_H
 #define VK_MODULE_H
 
-#include "vk_core.h"
-
-typedef enum {
-	RVkModuleResult_Success = 0
-} RVkModuleResult;
+#include "vk_common.h"
 
 typedef uint8_t RVkModuleState;
 enum {
-	RVkModuleState_None               = 0,
-	RVkModuleState_PreInitialized     = 1,
-	RVkModuleState_Initialized        = 2,
-	RVkModuleState_FailedToInitialize = 3,
-	RVkModuleState_ManualShutdown     = 4,
-	RVkModuleState_ForcedShutdown     = 5,
+	RVkModuleState_NotInitialized      = 0,
+	RVkModuleState_IsInitializing      = 1,
+	RVkModuleState_Initialized         = 2,
+	RVkModuleState_Shutdown            = 3,
 
 	RVkModuleState_COUNT
 };
 
+/* NOTE(nilsoncore): Unused for now. We should decide whether we keep this or not.
 typedef uint8_t RVkModuleLogLevels;
 enum {
 	RVkModuleLogLevels_None    = 0,
@@ -42,56 +37,85 @@ enum {
 	RVkModuleLogLevels_All = RVkModuleLogLevels_AllExceptDebug |
 	                         RVkModuleLogLevels_Debug
 };
+*/
 
 // Forward declare it so we can use it right below before we actually declare its' body.
 typedef struct RVkModule RVkModule; 
 
 typedef struct RVkModuleDependencies {
-	const char **required_module_names;
-	struct RVkModule *modules;
+	RVkModule **modules;
 	uint32_t count;
 } RVkModuleDependencies;
 
-typedef struct RVkModuleArgs {
-	char **args;
-	uint32_t count;
-} RVkModuleArgs;
+#define RVkModuleDependencies_Empty { .modules = NULL, .count = 0 }
+#define RVkModuleDependencies_FromStaticArray( array ) { .modules = array, .count = ( uint32_t ) COUNTOF( array ) }
 
-// Shortcut to inline-create empty argument list.
-// Usage:  module.Init( log_levels, RVkModuleArgs_Empty );
-#define RVkModuleArgs_Empty ( RVkModuleArgs ){ .args = NULL, .count = 0 }
+typedef qboolean ( *RVkModulePfn_Init )( void );
+typedef     void ( *RVkModulePfn_Shutdown )( void );
 
-typedef uint64_t RVkModuleNameHash;
+#define XRVkModule_OnInitStart( module ) do { \
+	if ( module.state == RVkModuleState_Initialized ) { \
+		return true; \
+	} \
+	if ( module.init_caller != NULL ) { \
+		gEngine.Con_Printf( "RVkModule: Initializing '%s' from '%s'...\n", module.name, module.init_caller->name ); \
+	} else { \
+		gEngine.Con_Printf( "RVkModule: Initializing '%s'...\n", module.name ); \
+	} \
+	module.state = RVkModuleState_IsInitializing; \
+	qboolean deps_inited = RVkModule_InitDependencies( &module ); \
+	if ( !deps_inited ) { \
+		gEngine.Con_Printf( S_ERROR "RVkModule: Failed to init dependencies for '%s'.\n", module.name ); \
+		module.state = RVkModuleState_NotInitialized; \
+		return false; \
+	} \
+} while(0)
 
-typedef RVkModuleResult ( *RVkModulePfn_Init )( RVkModuleLogLevels /*log_levels*/, RVkModuleArgs /*args*/ );
-typedef    const char * ( *RVkModulePfn_GetResultName )( RVkModuleResult /*result*/ );
-typedef            void ( *RVkModulePfn_Shutdown )( qboolean /*forced*/ );
+#define XRVkModule_OnInitEnd( module ) do { \
+	module.state = RVkModuleState_Initialized; \
+	if ( module.init_caller != NULL ) { \
+		gEngine.Con_Printf( "RVkModule: '%s' from '%s' has been initialized.\n", module.name, module.init_caller->name ); \
+	} else { \
+		gEngine.Con_Printf( "RVkModule: '%s' has been initialized.\n", module.name ); \
+	} \
+} while(0)
+
+#define XRVkModule_OnShutdownStart( module ) do { \
+	if ( module.state != RVkModuleState_Initialized ) { \
+		return; \
+	} \
+	gEngine.Con_Printf( "RVkModule: Shutting down '%s'...\n", module.name ); \
+} while(0)
+
+#define XRVkModule_OnShutdownEnd( module ) do { \
+	module.state = RVkModuleState_Shutdown; \
+	gEngine.Con_Printf( "RVkModule: '%s' has been shut down.\n", module.name ); \
+} while(0)
 
 typedef struct RVkModule {
-	// `PreInitialization`-filled fields.
-	// These fields are should be set in `vk_xxx.c` files by declaring global variable `g_module_xxx`
-	// and manually setting proper values and function pointers.
 	const char *name;
-	void *data;
 	RVkModuleState state;
 
 	RVkModuleDependencies dependencies;
 	uint32_t reference_count;
 
-	RVkModulePfn_Init          Init;
-	RVkModulePfn_GetResultName GetResultName;
-	RVkModulePfn_Shutdown      Shutdown;
+	RVkModule *init_caller;
 
-	// `Initialization`-filled fields.
-	// These fields are should be set after successful `Init` function completion.
-	RVkModuleNameHash hash;
-	RVkModuleLogLevels log_levels;
+	RVkModulePfn_Init     Init;
+	RVkModulePfn_Shutdown Shutdown;
+
+	// NOTE(nilsoncore): Unused for now. See comment above.
+	// RVkModuleLogLevels log_levels;
 } RVkModule;
 
-uint32_t RVkModule_InitAll( RVkModule* modules, uint32_t count );
+qboolean    RVkModule_OnInitStart( RVkModule *module );
+void        RVkModule_OnInitEnd( RVkModule *module);
+qboolean    RVkModule_OnShutdownStart( RVkModule *module );
+void        RVkModule_OnShutdownEnd( RVkModule *module );
+
+qboolean    RVkModule_InitDependencies( RVkModule *module );
+void        RVkModule_PrintDependencyList( RVkModule *module, qboolean print_states );
+void        RVkModule_PrintDependencyTree( RVkModule *module ); // TODO(nilsoncore)
 const char *RVkModule_GetStateName( RVkModuleState state );
-RVkModuleNameHash RVkModule_GetNameHash( const char *name ); // Not implemented yet. (stub)
-qboolean RVkModule_IsPreInitialized( RVkModule *module );
-qboolean RVkModule_IsInitialized( RVkModule *module );
 
 #endif /* VK_MODULE_H */

--- a/ref/vk/vk_module.h
+++ b/ref/vk/vk_module.h
@@ -65,7 +65,7 @@ typedef uint64_t RVkModuleNameHash;
 
 typedef RVkModuleResult ( *RVkModulePfn_Init )( RVkModuleLogLevels /*log_levels*/, RVkModuleArgs /*args*/ );
 typedef    const char * ( *RVkModulePfn_GetResultName )( RVkModuleResult /*result*/ );
-typedef            void ( *RVkModulePfn_Shutdown )( void );
+typedef            void ( *RVkModulePfn_Shutdown )( qboolean /*forced*/ );
 
 typedef struct RVkModule {
 	// `PreInitialization`-filled fields.

--- a/ref/vk/vk_nv_aftermath.h
+++ b/ref/vk/vk_nv_aftermath.h
@@ -1,14 +1,13 @@
 #pragma once
 
+#include "vk_module.h"
+
 #include "xash3d_types.h"
 
 #define VK_NO_PROTOTYPES
 #include <vulkan/vulkan.h>
 
-#ifdef USE_AFTERMATH
-qboolean VK_AftermathInit();
-void VK_AftermathShutdown();
-#endif
+extern RVkModule g_module_nv_aftermath;
 
 void R_Vk_NV_CheckpointF(VkCommandBuffer cmdbuf, const char *fmt, ...);
 void R_Vk_NV_Checkpoint_Dump(void);

--- a/ref/vk/vk_overlay.h
+++ b/ref/vk/vk_overlay.h
@@ -1,15 +1,16 @@
 #pragma once
 
 #include "vk_core.h"
+#include "vk_module.h"
+
 #include "xash3d_types.h"
+
+extern RVkModule g_module_overlay;
 
 void R_DrawStretchRaw( float x, float y, float w, float h, int cols, int rows, const byte *data, qboolean dirty );
 void R_DrawStretchPic( float x, float y, float w, float h, float s1, float t1, float s2, float t2, int texnum );
 void R_DrawTileClear( int texnum, int x, int y, int w, int h );
 void CL_FillRGBA( float x, float y, float w, float h, int r, int g, int b, int a );
 void CL_FillRGBABlend( float x, float y, float w, float h, int r, int g, int b, int a );
-
-qboolean R_VkOverlay_Init( void );
-void R_VkOverlay_Shutdown( void );
 
 void R_VkOverlay_DrawAndFlip( VkCommandBuffer cmdbuf, qboolean draw );

--- a/ref/vk/vk_pipeline.h
+++ b/ref/vk/vk_pipeline.h
@@ -1,7 +1,13 @@
 #pragma once
 
 #include "vk_core.h"
+#include "vk_module.h"
+
 #include "vk_buffer.h"
+
+extern RVkModule g_module_pipeline;
+
+extern VkPipelineCache g_pipeline_cache;
 
 VkShaderModule R_VkShaderLoadFromMem(const void *ptr, uint32_t size, const char *name);
 void R_VkShaderDestroy(VkShaderModule module);
@@ -83,9 +89,3 @@ vk_pipeline_ray_t VK_PipelineRayTracingCreate(const vk_pipeline_ray_create_info_
 struct vk_combuf_s;
 void VK_PipelineRayTracingTrace(struct vk_combuf_s *combuf, const vk_pipeline_ray_t *pipeline, uint32_t width, uint32_t height, int scope_id);
 void VK_PipelineRayTracingDestroy(vk_pipeline_ray_t* pipeline);
-
-
-qboolean VK_PipelineInit( void );
-void VK_PipelineShutdown( void );
-
-extern VkPipelineCache g_pipeline_cache;

--- a/ref/vk/vk_ray_accel.c
+++ b/ref/vk/vk_ray_accel.c
@@ -674,7 +674,7 @@ static qboolean Impl_Init( void ) {
 		gEngine.Con_Printf( S_NOTE "Module '%s' is initialized with enabled functionality.\n", g_module_ray_accel.name );
 	} else {
 		gEngine.Con_Printf( S_WARN "Module '%s' is initialized with disabled functionality.\n", g_module_ray_accel.name );
-		gEngine.Con_Printf( S_WARN "Switch to Ray Tracing renderer to enable it. (It must be supported on your graphics device)\n", g_module_ray_model.name );
+		gEngine.Con_Printf( S_WARN "Switch to Ray Tracing renderer to enable it. (It must be supported on your graphics device)\n" );
 	}
 
 	XRVkModule_OnInitEnd( g_module_ray_accel );

--- a/ref/vk/vk_ray_accel.c
+++ b/ref/vk/vk_ray_accel.c
@@ -18,6 +18,34 @@
 #define MODULE_NAME "accel"
 #define LOG_MODULE rt
 
+static qboolean Impl_Init( void );
+static     void Impl_Shutdown( void );
+
+static RVkModule *required_modules[] = {
+	// Impl_Init: VK_BufferCreate
+	// Impl_Shutdown: VK_BufferDestroy
+	&g_module_buffer,
+
+	// buildAccel: R_VkStagingCommit
+	// RT_VkAccelPrepareTlas: R_VkStagingLockForBuffer, R_VkStagingUnlock
+	&g_module_staging,
+
+	// buildAccel: R_VkGpuScope_Register, R_VkCombufScopeBegin, R_VkCombufScopeEnd
+	&g_module_combuf,
+
+	// createOrUpdateAccelerationStructure: R_GeometryBuffer_Get
+	// RT_BlasBuild: R_GeometryBuffer_Get
+	&g_module_geometry
+};
+
+RVkModule g_module_ray_accel = {
+	.name = "ray_accel",
+	.state = RVkModuleState_NotInitialized,
+	.dependencies = RVkModuleDependencies_FromStaticArray( required_modules ),
+	.Init = Impl_Init,
+	.Shutdown = Impl_Shutdown
+};
+
 typedef struct rt_blas_s {
 	const char *debug_name;
 	rt_blas_usage_e usage;
@@ -365,54 +393,6 @@ vk_resource_t RT_VkAccelPrepareTlas(vk_combuf_t *combuf) {
 	};
 }
 
-qboolean RT_VkAccelInit(void) {
-	if (!VK_BufferCreate("ray accels_buffer", &g_accel.accels_buffer, MAX_ACCELS_BUFFER,
-			VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
-			VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT
-		))
-	{
-		return false;
-	}
-	g_accel.accels_buffer_addr = R_VkBufferGetDeviceAddress(g_accel.accels_buffer.buffer);
-
-	if (!VK_BufferCreate("ray scratch_buffer", &g_accel.scratch_buffer, MAX_SCRATCH_BUFFER,
-			VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
-			VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT
-		)) {
-		return false;
-	}
-	g_accel.scratch_buffer_addr = R_VkBufferGetDeviceAddress(g_accel.scratch_buffer.buffer);
-
-	// TODO this doesn't really need to be host visible, use staging
-	if (!VK_BufferCreate("ray tlas_geom_buffer", &g_accel.tlas_geom_buffer, sizeof(VkAccelerationStructureInstanceKHR) * MAX_INSTANCES * 2,
-			VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT |
-			VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR,
-			VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)) {
-		// FIXME complain, handle
-		return false;
-	}
-	g_accel.tlas_geom_buffer_addr = R_VkBufferGetDeviceAddress(g_accel.tlas_geom_buffer.buffer);
-	R_FlippingBuffer_Init(&g_accel.tlas_geom_buffer_alloc, MAX_INSTANCES * 2);
-
-	g_accel.accels_buffer_alloc = aloPoolCreate(MAX_ACCELS_BUFFER, MAX_INSTANCES, /* why */ 256);
-
-	R_SPEEDS_COUNTER(g_accel.stats.instances_count, "instances", kSpeedsMetricCount);
-	R_SPEEDS_COUNTER(g_accel.stats.accels_built, "built", kSpeedsMetricCount);
-
-	return true;
-}
-
-void RT_VkAccelShutdown(void) {
-	if (g_accel.tlas != VK_NULL_HANDLE)
-		vkDestroyAccelerationStructureKHR(vk_core.device, g_accel.tlas, NULL);
-
-	VK_BufferDestroy(&g_accel.scratch_buffer);
-	VK_BufferDestroy(&g_accel.accels_buffer);
-	VK_BufferDestroy(&g_accel.tlas_geom_buffer);
-	if (g_accel.accels_buffer_alloc)
-		aloPoolDestroy(g_accel.accels_buffer_alloc);
-}
-
 void RT_VkAccelNewMap(void) {
 	const int expected_accels = 512; // TODO actually get this from playing the game
 	const int accels_alignment = 256; // TODO where does this come from?
@@ -646,4 +626,74 @@ finalize:
 	Mem_Free(max_prim_counts);
 	Mem_Free(build_ranges);
 	return retval;
+}
+
+static qboolean Impl_Init( void ) {
+	XRVkModule_OnInitStart( g_module_ray_accel );
+
+	if ( vk_core.rtx ) {
+		if (!VK_BufferCreate("ray accels_buffer", &g_accel.accels_buffer, MAX_ACCELS_BUFFER,
+				VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
+				VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT))
+		{
+			ERR( "Couldn't create Ray accelerations buffer." );
+			g_module_ray_accel.state = RVkModuleState_NotInitialized;
+			return false;
+		}
+		g_accel.accels_buffer_addr = R_VkBufferGetDeviceAddress(g_accel.accels_buffer.buffer);
+
+		if (!VK_BufferCreate("ray scratch_buffer", &g_accel.scratch_buffer, MAX_SCRATCH_BUFFER,
+				VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
+				VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT))
+		{
+			ERR( "Couldn't create Ray scratch buffer." );
+			g_module_ray_accel.state = RVkModuleState_NotInitialized;
+			return false;
+		}
+		g_accel.scratch_buffer_addr = R_VkBufferGetDeviceAddress(g_accel.scratch_buffer.buffer);
+
+		// TODO this doesn't really need to be host visible, use staging
+		if (!VK_BufferCreate("ray tlas_geom_buffer", &g_accel.tlas_geom_buffer, sizeof(VkAccelerationStructureInstanceKHR) * MAX_INSTANCES * 2,
+				VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT |
+				VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR,
+				VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT))
+		{
+			// FIXME complain, handle -- NOTE(nilsoncore): Is it done?
+			ERR( "Couldn't create Ray TLAS geometry buffer." );
+			g_module_ray_accel.state = RVkModuleState_NotInitialized;
+			return false;
+		}
+		g_accel.tlas_geom_buffer_addr = R_VkBufferGetDeviceAddress(g_accel.tlas_geom_buffer.buffer);
+		R_FlippingBuffer_Init(&g_accel.tlas_geom_buffer_alloc, MAX_INSTANCES * 2);
+
+		g_accel.accels_buffer_alloc = aloPoolCreate(MAX_ACCELS_BUFFER, MAX_INSTANCES, /* why */ 256);
+
+		R_SPEEDS_COUNTER(g_accel.stats.instances_count, "instances", kSpeedsMetricCount);
+		R_SPEEDS_COUNTER(g_accel.stats.accels_built, "built", kSpeedsMetricCount);
+
+		gEngine.Con_Printf( S_NOTE "Module '%s' is initialized with enabled functionality.\n", g_module_ray_accel.name );
+	} else {
+		gEngine.Con_Printf( S_WARN "Module '%s' is initialized with disabled functionality.\n", g_module_ray_accel.name );
+		gEngine.Con_Printf( S_WARN "Switch to Ray Tracing renderer to enable it. (It must be supported on your graphics device)\n", g_module_ray_model.name );
+	}
+
+	XRVkModule_OnInitEnd( g_module_ray_accel );
+	return true;
+}
+
+static void Impl_Shutdown( void ) {
+	XRVkModule_OnShutdownStart( g_module_ray_accel );
+
+	if ( vk_core.rtx ) {
+		if (g_accel.tlas != VK_NULL_HANDLE)
+			vkDestroyAccelerationStructureKHR(vk_core.device, g_accel.tlas, NULL);
+
+		VK_BufferDestroy(&g_accel.scratch_buffer);
+		VK_BufferDestroy(&g_accel.accels_buffer);
+		VK_BufferDestroy(&g_accel.tlas_geom_buffer);
+		if (g_accel.accels_buffer_alloc)
+			aloPoolDestroy(g_accel.accels_buffer_alloc);
+	}
+
+	XRVkModule_OnShutdownEnd( g_module_ray_accel );
 }

--- a/ref/vk/vk_ray_accel.h
+++ b/ref/vk/vk_ray_accel.h
@@ -1,12 +1,13 @@
 #pragma once
 
 #include "vk_core.h"
+#include "vk_module.h"
+
 #include "vk_buffer.h"
 #include "vk_math.h"
 #include "ray_resources.h"
 
-qboolean RT_VkAccelInit(void);
-void RT_VkAccelShutdown(void);
+extern RVkModule g_module_ray_accel;
 
 void RT_VkAccelNewMap(void);
 void RT_VkAccelFrameBegin(void);

--- a/ref/vk/vk_ray_internal.h
+++ b/ref/vk/vk_ray_internal.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "vk_core.h"
+#include "vk_module.h"
+
 #include "vk_buffer.h"
 #include "vk_const.h"
 #include "vk_rtx.h"
@@ -10,6 +12,8 @@
 #define MODEL_CACHE_SIZE 2048
 
 #include "shaders/ray_interop.h"
+
+extern RVkModule g_module_ray_model;
 
 typedef struct Kusok vk_kusok_data_t;
 
@@ -103,8 +107,5 @@ void RT_KusochkiFree(const rt_kusochki_t*);
 
 //struct vk_render_geometry_s;
 //qboolean RT_KusochkiUpload(uint32_t kusochki_offset, const struct vk_render_geometry_s *geoms, int geoms_count, int override_texture_id, const vec4_t *override_color);
-
-qboolean RT_DynamicModelInit(void);
-void RT_DynamicModelShutdown(void);
 
 void RT_DynamicModelProcessFrame(void);

--- a/ref/vk/vk_ray_model.c
+++ b/ref/vk/vk_ray_model.c
@@ -504,7 +504,7 @@ static qboolean Impl_Init( void ) {
 		gEngine.Con_Printf( S_NOTE "Module '%s' is initialized with enabled functionality.\n", g_module_ray_model.name );
 	} else {
 		gEngine.Con_Printf( S_WARN "Module '%s' is initialized with disabled functionality.\n", g_module_ray_model.name );
-		gEngine.Con_Printf( S_WARN "Switch to Ray Tracing renderer to enable it. (It must be supported on your graphics device)\n", g_module_ray_model.name );
+		gEngine.Con_Printf( S_WARN "Switch to Ray Tracing renderer to enable it. (It must be supported on your graphics device)\n" );
 	}
 
 	XRVkModule_OnInitEnd( g_module_ray_model );

--- a/ref/vk/vk_ray_model.c
+++ b/ref/vk/vk_ray_model.c
@@ -12,10 +12,36 @@
 #include "vk_logs.h"
 #include "profiler.h"
 
+#include "vk_ray_accel.h" // Blas
+
 #include "eiface.h"
 #include "xash3d_mathlib.h"
 
 #include <string.h>
+
+static qboolean Impl_Init( void );
+static     void Impl_Shutdown( void );
+
+static RVkModule *required_modules[] = {
+	// RT_KusochkiUpload: R_VkStagingLockForBuffer, R_VkStagingUnlock
+	&g_module_staging,
+
+	// RT_ModelCreate: RT_BlasCreate, RT_BlasBuild, RT_BlasGetDeviceAddress, RT_BlasDestroy
+	// RT_ModelDestroy: RT_BlasDestroy
+	// RT_ModelUpdate: RT_BlasBuild
+	// RT_DynamicModelProcessFrame: RT_BlasBuild
+	// Impl_Init: RT_BlasCreate, RT_BlasPreallocate, RT_BlasGetDeviceAddress
+	// Impl_Shutdown: RT_BlasDestroy
+	&g_module_ray_accel
+};
+
+RVkModule g_module_ray_model = {
+	.name = "ray_model",
+	.state = RVkModuleState_NotInitialized,
+	.dependencies = RVkModuleDependencies_FromStaticArray( required_modules ),
+	.Init = Impl_Init,
+	.Shutdown = Impl_Shutdown
+};
 
 xvk_ray_model_state_t g_ray_model_state;
 
@@ -389,38 +415,6 @@ static struct {
 	rt_dynamic_t groups[MATERIAL_MODE_COUNT];
 } g_dyn;
 
-qboolean RT_DynamicModelInit(void) {
-	for (int i = 0; i < MATERIAL_MODE_COUNT; ++i) {
-		struct rt_blas_s *blas = RT_BlasCreate(group_names[i], kBlasBuildDynamicFast);
-		if (!blas) {
-			// FIXME destroy allocated
-			gEngine.Con_Printf(S_ERROR "Couldn't create blas for %s\n", group_names[i]);
-			return false;
-		}
-
-		if (!RT_BlasPreallocate(blas, (rt_blas_preallocate_t){
-			// TODO better estimates for these constants
-			.max_geometries = MAX_RT_DYNAMIC_GEOMETRIES,
-			.max_prims_per_geometry = 256,
-			.max_vertex_per_geometry = 256,
-		})) {
-			// FIXME destroy allocated
-			gEngine.Con_Printf(S_ERROR "Couldn't preallocate blas for %s\n", group_names[i]);
-			return false;
-		}
-		g_dyn.groups[i].blas = blas;
-		g_dyn.groups[i].blas_addr = RT_BlasGetDeviceAddress(blas);
-	}
-
-	return true;
-}
-
-void RT_DynamicModelShutdown(void) {
-	for (int i = 0; i < MATERIAL_MODE_COUNT; ++i) {
-		RT_BlasDestroy(g_dyn.groups[i].blas);
-	}
-}
-
 void RT_DynamicModelProcessFrame(void) {
 	APROF_SCOPE_DECLARE_BEGIN(process, __FUNCTION__);
 	for (int i = 0; i < MATERIAL_MODE_COUNT; ++i) {
@@ -479,3 +473,52 @@ void RT_FrameAddOnce( rt_frame_add_once_t args ) {
 	}
 }
 
+static qboolean Impl_Init( void ) {
+	XRVkModule_OnInitStart( g_module_ray_model );
+
+	if ( vk_core.rtx ) {
+		for (int i = 0; i < MATERIAL_MODE_COUNT; ++i) {
+			struct rt_blas_s *blas = RT_BlasCreate(group_names[i], kBlasBuildDynamicFast);
+			if (!blas) {
+				// FIXME destroy allocated
+				gEngine.Con_Printf(S_ERROR "Couldn't create BLAS for %s\n", group_names[i]);
+				g_module_ray_model.state = RVkModuleState_NotInitialized;
+				return false;
+			}
+
+			if (!RT_BlasPreallocate(blas, (rt_blas_preallocate_t){
+				// TODO better estimates for these constants
+				.max_geometries = MAX_RT_DYNAMIC_GEOMETRIES,
+				.max_prims_per_geometry = 256,
+				.max_vertex_per_geometry = 256,
+			})) {
+				// FIXME destroy allocated
+				gEngine.Con_Printf(S_ERROR "Couldn't preallocate BLAS for %s\n", group_names[i]);
+				g_module_ray_model.state = RVkModuleState_NotInitialized;
+				return false;
+			}
+			g_dyn.groups[i].blas = blas;
+			g_dyn.groups[i].blas_addr = RT_BlasGetDeviceAddress(blas);
+		}
+
+		gEngine.Con_Printf( S_NOTE "Module '%s' is initialized with enabled functionality.\n", g_module_ray_model.name );
+	} else {
+		gEngine.Con_Printf( S_WARN "Module '%s' is initialized with disabled functionality.\n", g_module_ray_model.name );
+		gEngine.Con_Printf( S_WARN "Switch to Ray Tracing renderer to enable it. (It must be supported on your graphics device)\n", g_module_ray_model.name );
+	}
+
+	XRVkModule_OnInitEnd( g_module_ray_model );
+	return true;
+}
+
+static void Impl_Shutdown( void ) {
+	XRVkModule_OnShutdownStart( g_module_ray_model );
+
+	if ( vk_core.rtx ) {
+		for (int i = 0; i < MATERIAL_MODE_COUNT; ++i) {
+			RT_BlasDestroy(g_dyn.groups[i].blas);
+		}
+	}
+
+	XRVkModule_OnShutdownEnd( g_module_ray_model );
+}

--- a/ref/vk/vk_render.c
+++ b/ref/vk/vk_render.c
@@ -36,6 +36,48 @@
 PROFILER_SCOPES(SCOPE_DECLARE)
 #undef SCOPE_DECLARE
 
+static qboolean Impl_Init( void );
+static     void Impl_Shutdown( void );
+
+static RVkModule *required_modules[] = {
+	// Impl_Init: VK_BufferCreate
+	// Impl_Shutdown: VK_BufferDestroy
+	&g_module_buffer,
+
+	// createPipelines: VK_PipelineGraphicsCreate
+	&g_module_pipeline,
+
+	// VK_RenderBegin: VK_RayFrameBegin
+	// VK_RenderEndRTX: VK_RayFrameEnd
+	&g_module_rtx,
+
+	// R_RenderModelCreate: RT_ModelCreate
+	// R_RenderModelDestroy: RT_ModelDestroy
+	// R_RenderModelUpdate: RT_ModelUpdate
+	// R_RenderModelUpdateMaterials: RT_ModelUpdateMaterials
+	// R_RenderModelDraw: RT_FrameAddModel
+	// R_RenderDrawOnce: RT_FrameAddOnce
+	// &g_module_ray_model, -- NOTE(nilsoncore): For some reason we don't see this module although we use its functions?? Whatever, it's inside rtx anyway.
+
+	// VK_Render_FIXME_Barrier: R_GeometryBuffer_Get
+	// VK_RenderEnd: R_GeometryBuffer_Get
+	// VK_RenderEndRTX: R_GeometryBuffer_Get
+	// R_RenderDrawOnce: R_GeometryBufferAllocOnceAndLock, R_GeometryBufferUnlock
+	&g_module_geometry,
+
+	// VK_RenderEnd: R_VkTextureGetDescriptorUnorm
+	&g_module_textures_api, // It has to be loaded first
+	// &g_module_textures -- @TexturesInitHardcode
+};
+
+RVkModule g_module_render = {
+	.name = "render",
+	.state = RVkModuleState_NotInitialized,
+	.dependencies = RVkModuleDependencies_FromStaticArray( required_modules ),
+	.Init = Impl_Init,
+	.Shutdown = Impl_Shutdown
+};
+
 typedef struct {
 	matrix4x4 mvp;
 	vec4_t color;
@@ -293,70 +335,6 @@ static struct {
 
 	qboolean current_frame_is_ray_traced;
 } g_render_state;
-
-qboolean VK_RenderInit( void ) {
-	PROFILER_SCOPES(APROF_SCOPE_INIT);
-
-	g_render.use_material_textures = gEngine.Cvar_Get( "vk_use_material_textures", "0", FCVAR_GLCONFIG, "Use PBR material textures for traditional rendering too" );
-
-	g_render.ubo_align = Q_max(4, vk_core.physical_device.properties.limits.minUniformBufferOffsetAlignment);
-
-	const uint32_t uniform_unit_size = ((sizeof(uniform_data_t) + g_render.ubo_align - 1) / g_render.ubo_align) * g_render.ubo_align;
-	const uint32_t uniform_buffer_size = uniform_unit_size * MAX_UNIFORM_SLOTS;
-	R_FlippingBuffer_Init(&g_render_state.uniform_alloc, uniform_buffer_size);
-
-	if (!VK_BufferCreate("render uniform_buffer", &g_render.uniform_buffer, uniform_buffer_size,
-		VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
-		VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT | (vk_core.rtx ? VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT : 0)))
-		return false;
-
-	{
-		VkDescriptorBufferInfo dbi_uniform_data = {
-			.buffer = g_render.uniform_buffer.buffer,
-			.offset = 0,
-			.range = sizeof(uniform_data_t),
-		};
-		VkDescriptorBufferInfo dbi_uniform_lights = {
-			.buffer = g_render.uniform_buffer.buffer,
-			.offset = 0,
-			.range = sizeof(vk_ubo_lights_t),
-		};
-		VkWriteDescriptorSet wds[] = {{
-				.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
-				.dstBinding = 0,
-				.dstArrayElement = 0,
-				.descriptorCount = 1,
-				.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
-				.pBufferInfo = &dbi_uniform_data,
-				.dstSet = vk_desc_fixme.ubo_sets[0], // FIXME
-			}, {
-				.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
-				.dstBinding = 0,
-				.dstArrayElement = 0,
-				.descriptorCount = 1,
-				.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
-				.pBufferInfo = &dbi_uniform_lights,
-				.dstSet = vk_desc_fixme.ubo_sets[1], // FIXME
-			}};
-		vkUpdateDescriptorSets(vk_core.device, ARRAYSIZE(wds), wds, 0, NULL);
-	}
-
-	if (!createPipelines())
-		return false;
-
-	R_SPEEDS_COUNTER(g_render.stats.dynamic_model_count, "models_dynamic", kSpeedsMetricCount);
-	R_SPEEDS_COUNTER(g_render.stats.models_count, "models", kSpeedsMetricCount);
-	return true;
-}
-
-void VK_RenderShutdown( void )
-{
-	for (int i = 0; i < ARRAYSIZE(g_render.pipelines); ++i)
-		vkDestroyPipeline(vk_core.device, g_render.pipelines[i], NULL);
-	vkDestroyPipelineLayout( vk_core.device, g_render.pipeline_layout, NULL );
-
-	VK_BufferDestroy( &g_render.uniform_buffer );
-}
 
 enum {
 	UNIFORM_UNSET = 0,
@@ -861,4 +839,82 @@ void R_RenderDrawOnce(r_draw_once_t args) {
 	}
 
 	g_render.stats.dynamic_model_count++;
+}
+
+static qboolean Impl_Init( void ) {
+	PROFILER_SCOPES(APROF_SCOPE_INIT);
+	
+	XRVkModule_OnInitStart( g_module_render );
+
+	g_render.use_material_textures = gEngine.Cvar_Get( "vk_use_material_textures", "0", FCVAR_GLCONFIG, "Use PBR material textures for traditional rendering too" );
+
+	g_render.ubo_align = Q_max(4, vk_core.physical_device.properties.limits.minUniformBufferOffsetAlignment);
+
+	const uint32_t uniform_unit_size = ((sizeof(uniform_data_t) + g_render.ubo_align - 1) / g_render.ubo_align) * g_render.ubo_align;
+	const uint32_t uniform_buffer_size = uniform_unit_size * MAX_UNIFORM_SLOTS;
+	R_FlippingBuffer_Init(&g_render_state.uniform_alloc, uniform_buffer_size);
+
+	if (!VK_BufferCreate("render uniform_buffer", &g_render.uniform_buffer, uniform_buffer_size,
+		VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
+		VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT | (vk_core.rtx ? VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT : 0))) {
+		gEngine.Con_Printf( S_ERROR "Couldn't create uniform render buffer.\n" );
+		g_module_render.state = RVkModuleState_NotInitialized;
+		return false;
+	}
+
+	{
+		VkDescriptorBufferInfo dbi_uniform_data = {
+			.buffer = g_render.uniform_buffer.buffer,
+			.offset = 0,
+			.range = sizeof(uniform_data_t),
+		};
+		VkDescriptorBufferInfo dbi_uniform_lights = {
+			.buffer = g_render.uniform_buffer.buffer,
+			.offset = 0,
+			.range = sizeof(vk_ubo_lights_t),
+		};
+		VkWriteDescriptorSet wds[] = {{
+				.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+				.dstBinding = 0,
+				.dstArrayElement = 0,
+				.descriptorCount = 1,
+				.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
+				.pBufferInfo = &dbi_uniform_data,
+				.dstSet = vk_desc_fixme.ubo_sets[0], // FIXME
+			}, {
+				.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+				.dstBinding = 0,
+				.dstArrayElement = 0,
+				.descriptorCount = 1,
+				.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
+				.pBufferInfo = &dbi_uniform_lights,
+				.dstSet = vk_desc_fixme.ubo_sets[1], // FIXME
+			}};
+		vkUpdateDescriptorSets(vk_core.device, ARRAYSIZE(wds), wds, 0, NULL);
+	}
+
+	if (!createPipelines()) {
+		gEngine.Con_Printf( S_ERROR "Couldn't create render pipelines.\n" );
+		g_module_render.state = RVkModuleState_NotInitialized;
+		return false;
+	}
+
+	R_SPEEDS_COUNTER(g_render.stats.dynamic_model_count, "models_dynamic", kSpeedsMetricCount);
+	R_SPEEDS_COUNTER(g_render.stats.models_count, "models", kSpeedsMetricCount);
+
+	XRVkModule_OnInitEnd( g_module_render );
+	return true;
+}
+
+static void Impl_Shutdown( void ) {
+	XRVkModule_OnShutdownStart( g_module_render );
+
+	for (int i = 0; i < ARRAYSIZE(g_render.pipelines); ++i)
+		vkDestroyPipeline(vk_core.device, g_render.pipelines[i], NULL);
+
+	vkDestroyPipelineLayout( vk_core.device, g_render.pipeline_layout, NULL );
+
+	VK_BufferDestroy( &g_render.uniform_buffer );
+
+	XRVkModule_OnShutdownEnd( g_module_render );
 }

--- a/ref/vk/vk_render.h
+++ b/ref/vk/vk_render.h
@@ -1,11 +1,13 @@
 #pragma once
+
+#include "vk_core.h"
+#include "vk_module.h"
+
 #include "vk_materials.h"
 #include "vk_common.h"
 #include "vk_const.h"
-#include "vk_core.h"
 
-qboolean VK_RenderInit( void );
-void VK_RenderShutdown( void );
+extern RVkModule g_module_render;
 
 struct ref_viewpass_s;
 void VK_RenderSetupCamera( const struct ref_viewpass_s *rvp );

--- a/ref/vk/vk_rtx.c
+++ b/ref/vk/vk_rtx.c
@@ -825,7 +825,7 @@ static qboolean Impl_Init( void ) {
 		gEngine.Con_Printf( S_NOTE "Module '%s' is initialized with enabled functionality.\n", g_module_rtx.name );
 	} else {
 		gEngine.Con_Printf( S_WARN "Module '%s' is initialized with disabled functionality.\n", g_module_rtx.name );
-		gEngine.Con_Printf( S_WARN "Switch to Ray Tracing renderer to enable it. (It must be supported on your graphics device)\n", g_module_ray_model.name );
+		gEngine.Con_Printf( S_WARN "Switch to Ray Tracing renderer to enable it. (It must be supported on your graphics device)\n" );
 	}
 
 	XRVkModule_OnInitEnd( g_module_rtx );

--- a/ref/vk/vk_rtx.c
+++ b/ref/vk/vk_rtx.c
@@ -56,6 +56,50 @@ enum {
 
 #define MAX_RESOURCES 32
 
+static qboolean Impl_Init( void );
+static     void Impl_Shutdown( void );
+
+static RVkModule *required_modules[] = {
+	// Impl_Init: VK_BufferCreate
+	// Impl_Shutdown: VK_BufferDestroy
+	&g_module_buffer,
+
+	// VK_RayNewMapBegin: RT_VkAccelNewMap
+	// VK_RayFrameBegin: RT_VkAccelFrameBegin
+	// performTracing: RT_VkAccelPrepareTlas
+	&g_module_ray_accel,
+
+	// VK_RayNewMapBegin: RT_RayModel_Clear
+	// VK_RayFrameBegin: XVK_RayModel_ClearForNextFrame
+	// VK_RayFrameEnd: RT_DynamicModelProcessFrame
+	// Impl_Init: RT_RayModel_Clear
+	&g_module_ray_model,
+
+	// VK_RayNewMapEnd: R_VkTexturesGetSkyboxDescriptorImageInfo, R_VkTexturesGetBlueNoiseImageInfo
+	// prepareUniformBuffer: R_TexturesGetSkyboxInfo
+	// Impl_Init: R_VkTexturesGetAllDescriptorsArray
+	&g_module_textures_api,
+	// &g_module_textures, -- @TexturesInitHardcode
+
+	// VK_RayFrameBegin: RT_LightsFrameBegin
+	// VK_RayFrameEnd: RT_LightsFrameEnd, VK_LightsUpload
+	&g_module_light,
+
+	// performTracing: R_VkImageBlit, R_VkImageClear
+	// cleanupResources: R_VkImageDestroy
+	// reloadMainpipe: R_VkImageDestroy, R_VkImageCreate
+	// VK_RayFrameEnd: R_VkImageClear, R_VkImageBlit
+	&g_module_image
+};
+
+RVkModule g_module_rtx = {
+	.name = "rtx",
+	.state = RVkModuleState_NotInitialized,
+	.dependencies = RVkModuleDependencies_FromStaticArray( required_modules ),
+	.Init = Impl_Init,
+	.Shutdown = Impl_Shutdown
+};
+
 typedef struct {
 		char name[64];
 		vk_resource_t resource;
@@ -700,91 +744,104 @@ static void reloadPipeline( void ) {
 	g_rtx.reload_pipeline = true;
 }
 
-qboolean VK_RayInit( void )
-{
-	ASSERT(vk_core.rtx);
-	// TODO complain and cleanup on failure
-
-	g_rtx.max_frame_width = MIN_FRAME_WIDTH;
-	g_rtx.max_frame_height = MIN_FRAME_HEIGHT;
-
-	if (!RT_VkAccelInit())
-		return false;
-
-	// FIXME shutdown accel
-	if (!RT_DynamicModelInit())
-		return false;
-
-#define REGISTER_EXTERNAL(type, name_) \
-	Q_strncpy(g_rtx.res[ExternalResource_##name_].name, #name_, sizeof(g_rtx.res[0].name)); \
-	g_rtx.res[ExternalResource_##name_].refcount = 1;
-	EXTERNAL_RESOUCES(REGISTER_EXTERNAL)
-#undef REGISTER_EXTERNAL
-
-	g_rtx.res[ExternalResource_textures].resource = (vk_resource_t){
-		.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-		.value = (vk_descriptor_value_t){
-			.image_array = R_VkTexturesGetAllDescriptorsArray(),
-		}
-	};
-	g_rtx.res[ExternalResource_textures].refcount = 1;
-
-	reloadMainpipe();
-	if (!g_rtx.mainpipe)
-		return false;
-
-	g_rtx.uniform_unit_size = ALIGN_UP(sizeof(struct UniformBuffer), vk_core.physical_device.properties.limits.minUniformBufferOffsetAlignment);
-
-	if (!VK_BufferCreate("ray uniform_buffer", &g_rtx.uniform_buffer, g_rtx.uniform_unit_size * MAX_FRAMES_IN_FLIGHT,
-		VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
-		VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT | VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT))
-	{
-		return false;
-	}
-
-	if (!VK_BufferCreate("ray kusochki_buffer", &g_ray_model_state.kusochki_buffer, sizeof(vk_kusok_data_t) * MAX_KUSOCHKI,
-		VK_BUFFER_USAGE_STORAGE_BUFFER_BIT  | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)) {
-		// FIXME complain, handle
-		return false;
-	}
-
-	if (!VK_BufferCreate("model headers", &g_ray_model_state.model_headers_buffer, sizeof(struct ModelHeader) * MAX_INSTANCES,
-		VK_BUFFER_USAGE_STORAGE_BUFFER_BIT  | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)) {
-		// FIXME complain, handle
-		return false;
-	}
-
-	RT_RayModel_Clear();
-
-	gEngine.Cmd_AddCommand("rt_debug_reload_pipelines", reloadPipeline, "Reload RT pipelines");
-
-#define X(name) #name ", "
-	g_rtx.debug.rt_debug_display_only = gEngine.Cvar_Get("rt_debug_display_only", "", FCVAR_GLCONFIG,
-		"Display only the specified channel (" LIST_DISPLAYS(X) "etc)");
-#undef X
-
-	g_rtx.debug.rt_debug_fixed_random_seed = gEngine.Cvar_Get("rt_debug_fixed_random_seed", "", FCVAR_GLCONFIG,
-		"Fix random seed value for RT monte carlo sampling. Used for reproducible regression testing");
-
-	return true;
-}
-
-void VK_RayShutdown( void ) {
-	ASSERT(vk_core.rtx);
-
-	destroyMainpipe();
-
-	VK_BufferDestroy(&g_ray_model_state.model_headers_buffer);
-	VK_BufferDestroy(&g_ray_model_state.kusochki_buffer);
-	VK_BufferDestroy(&g_rtx.uniform_buffer);
-
-	RT_VkAccelShutdown();
-	RT_DynamicModelShutdown();
-}
-
 void RT_FrameDiscontinuity( void ) {
 	DEBUG("%s", __FUNCTION__);
 	g_rtx.discontinuity = true;
+}
+
+static qboolean Impl_Init( void ) {
+	XRVkModule_OnInitStart( g_module_rtx );
+
+	// TODO complain and cleanup on failure
+	if ( vk_core.rtx ) {
+
+		g_rtx.max_frame_width = MIN_FRAME_WIDTH;
+		g_rtx.max_frame_height = MIN_FRAME_HEIGHT;
+
+#define REGISTER_EXTERNAL(type, name_) \
+		Q_strncpy(g_rtx.res[ExternalResource_##name_].name, #name_, sizeof(g_rtx.res[0].name)); \
+		g_rtx.res[ExternalResource_##name_].refcount = 1;
+		EXTERNAL_RESOUCES(REGISTER_EXTERNAL)
+#undef REGISTER_EXTERNAL
+
+		g_rtx.res[ExternalResource_textures].resource = (vk_resource_t){
+			.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+			.value = (vk_descriptor_value_t){
+				.image_array = R_VkTexturesGetAllDescriptorsArray(),
+			}
+		};
+		g_rtx.res[ExternalResource_textures].refcount = 1;
+
+		reloadMainpipe();
+		if (!g_rtx.mainpipe) {
+			ERR( "Couldn't reload Ray Tracing mainpipe." );
+			g_module_rtx.state = RVkModuleState_NotInitialized;
+			return false;
+		}
+
+		g_rtx.uniform_unit_size = ALIGN_UP(sizeof(struct UniformBuffer), vk_core.physical_device.properties.limits.minUniformBufferOffsetAlignment);
+
+		if (!VK_BufferCreate("ray uniform_buffer", &g_rtx.uniform_buffer, g_rtx.uniform_unit_size * MAX_FRAMES_IN_FLIGHT,
+			VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
+			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT | VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT))
+		{
+			ERR( "Couldn't create Ray Tracing uniform buffer." );
+			g_module_rtx.state = RVkModuleState_NotInitialized;
+			return false;
+		}
+
+		if (!VK_BufferCreate("ray kusochki_buffer", &g_ray_model_state.kusochki_buffer, sizeof(vk_kusok_data_t) * MAX_KUSOCHKI,
+			VK_BUFFER_USAGE_STORAGE_BUFFER_BIT  | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+			VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT))
+		{
+			// FIXME complain, handle
+			ERR( "Couldn't create Ray Tracing kusochki buffer." );
+			g_module_rtx.state = RVkModuleState_NotInitialized;
+			return false;
+		}
+
+		if (!VK_BufferCreate("model headers", &g_ray_model_state.model_headers_buffer, sizeof(struct ModelHeader) * MAX_INSTANCES,
+			VK_BUFFER_USAGE_STORAGE_BUFFER_BIT  | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+			VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT))
+		{
+			// FIXME complain, handle
+			ERR( "Couldn't create Ray Tracing model headers buffer." );
+			g_module_rtx.state = RVkModuleState_NotInitialized;
+			return false;
+		}
+
+		RT_RayModel_Clear();
+
+		gEngine.Cmd_AddCommand("rt_debug_reload_pipelines", reloadPipeline, "Reload RT pipelines");
+
+#define X(name) #name ", "
+		g_rtx.debug.rt_debug_display_only = gEngine.Cvar_Get("rt_debug_display_only", "", FCVAR_GLCONFIG,
+			"Display only the specified channel (" LIST_DISPLAYS(X) "etc)");
+#undef X
+
+		g_rtx.debug.rt_debug_fixed_random_seed = gEngine.Cvar_Get("rt_debug_fixed_random_seed", "", FCVAR_GLCONFIG,
+			"Fix random seed value for RT monte carlo sampling. Used for reproducible regression testing");
+
+		gEngine.Con_Printf( S_NOTE "Module '%s' is initialized with enabled functionality.\n", g_module_rtx.name );
+	} else {
+		gEngine.Con_Printf( S_WARN "Module '%s' is initialized with disabled functionality.\n", g_module_rtx.name );
+		gEngine.Con_Printf( S_WARN "Switch to Ray Tracing renderer to enable it. (It must be supported on your graphics device)\n", g_module_ray_model.name );
+	}
+
+	XRVkModule_OnInitEnd( g_module_rtx );
+	return true;
+}
+
+static void Impl_Shutdown( void ) {
+	XRVkModule_OnShutdownStart( g_module_rtx );
+	
+	if ( vk_core.rtx ) {
+		destroyMainpipe();
+
+		VK_BufferDestroy(&g_ray_model_state.model_headers_buffer);
+		VK_BufferDestroy(&g_ray_model_state.kusochki_buffer);
+		VK_BufferDestroy(&g_rtx.uniform_buffer);
+	}
+
+	XRVkModule_OnShutdownEnd( g_module_rtx );
 }

--- a/ref/vk/vk_rtx.h
+++ b/ref/vk/vk_rtx.h
@@ -1,7 +1,11 @@
 #pragma once
 
-#include "vk_geometry.h"
 #include "vk_core.h"
+#include "vk_module.h"
+
+#include "vk_geometry.h"
+
+extern RVkModule g_module_rtx;
 
 void VK_RayFrameBegin( void );
 
@@ -29,9 +33,6 @@ void VK_RayFrameEnd(const vk_ray_frame_render_args_t* args);
 
 void VK_RayNewMapBegin( void );
 void VK_RayNewMapEnd( void );
-
-qboolean VK_RayInit( void );
-void VK_RayShutdown( void );
 
 struct vk_render_geometry_s;
 struct rt_model_s;

--- a/ref/vk/vk_scene.h
+++ b/ref/vk/vk_scene.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#include "vk_module.h"
 #include "vk_const.h"
 
 #include "xash3d_types.h"
@@ -6,10 +8,10 @@
 #include "com_model.h"
 #include "ref_params.h"
 
+extern RVkModule g_module_scene;
+
 struct ref_viewpass_s;
 struct cl_entity_s;
-
-void VK_SceneInit( void );
 
 void VK_SceneRender( const struct ref_viewpass_s *rvp );
 
@@ -27,8 +29,6 @@ void R_RenderScene( void );
 int R_WorldToScreen( const vec3_t point, vec3_t screen );
 int TriWorldToScreen( const float *world, float *screen );
 
-// TODO should this be here?
-int CL_FxBlend( struct cl_entity_s *e );
 struct beam_s;
 void CL_DrawBeams( int fTrans, struct beam_s *active_beams );
 void CL_AddCustomBeam( struct cl_entity_s *pEnvBeam );

--- a/ref/vk/vk_sprite.h
+++ b/ref/vk/vk_sprite.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include "vk_module.h"
+
 #include "vk_common.h"
+
+extern RVkModule g_module_sprite;
 
 void R_GetSpriteParms( int *frameWidth, int *frameHeight, int *numFrames, int currentFrame, const model_t *pSprite );
 int R_GetSpriteTexture( const model_t *m_pSpriteModel, int frame );
@@ -8,9 +12,6 @@ void Mod_LoadMapSprite( struct model_s *mod, const void *buffer, size_t size, qb
 void Mod_LoadSpriteModel( model_t *mod, const void *buffer, qboolean *loaded, uint texFlags );
 
 void R_VkSpriteDrawModel( cl_entity_t *e, float blend );
-
-qboolean R_SpriteInit(void);
-void R_SpriteShutdown(void);
 
 // FIXME needed to recreate the sprite quad model, otherwise its memory will be freed, reused and corrupted
 void R_SpriteNewMapFIXME(void);

--- a/ref/vk/vk_staging.h
+++ b/ref/vk/vk_staging.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "vk_core.h"
+#include "vk_module.h"
 
-qboolean R_VkStagingInit(void);
-void R_VkStagingShutdown(void);
+extern RVkModule g_module_staging;
 
 typedef int staging_handle_t;
 

--- a/ref/vk/vk_studio.c
+++ b/ref/vk/vk_studio.c
@@ -38,6 +38,41 @@
 #define ENGINE_GET_PARM( parm ) ENGINE_GET_PARM_( ( parm ), 0 )
 #define CL_IsViewEntityLocalPlayer() ( ENGINE_GET_PARM( PARM_VIEWENT_INDEX ) == ENGINE_GET_PARM( PARM_PLAYER_INDEX ) )
 
+static qboolean Impl_Init( void );
+static     void Impl_Shutdown( void );
+
+static RVkModule *required_modules[] = {
+	// R_StudioDrawPoints: studioSubmodelRenderModelAcquire, studioSubmodelRenderModelRelease
+	// studioEntityModelDestroy: studioSubmodelRenderModelRelease
+	// studioEntityModelCreate: getStudioModelInfo
+	&g_module_studio_model,
+
+	// buildStudioSubmodelGeometry: R_GeometryRangeLock, R_GeometryRangeUnlock
+	// studioSubmodelRenderInit: R_GeometryRangeAlloc
+	&g_module_geometry,
+	
+	// studioSubmodelRenderInit: R_RenderModelCreate
+	// studioSubmodelRenderUpdate: R_RenderModelUpdate
+	// R_StudioDrawPoints: R_RenderModelDraw
+	// R_StudioRenderFinal: VK_RenderDebugLabelBegin, VK_RenderDebugLabelEnd
+	// R_StudioDrawModelInternal: VK_RenderDebugLabelBegin, VK_RenderDebugLabelEnd
+	&g_module_render,
+
+	// buildSubmodelMeshGeometry: R_VkMaterialGetForTextureWithFlags
+	&g_module_materials,
+
+	// R_StudioLoadTexture: R_TextureUploadFromFile
+	&g_module_textures_api
+};
+
+RVkModule g_module_studio = {
+	.name = "studio",
+	.state = RVkModuleState_NotInitialized,
+	.dependencies = RVkModuleDependencies_FromStaticArray( required_modules ),
+	.Init = Impl_Init,
+	.Shutdown = Impl_Shutdown
+};
+
 // FIXME VK should not be declared here
 colorVec		R_LightVec( const float *start, const float *end, float *lightspot, float *lightvec );
 
@@ -1576,9 +1611,6 @@ mstudiotexture_t *R_StudioGetTexture( cl_entity_t *e )
 
 	return ptexture;
 }
-
-// TODO where does this need to be declared and defined? currently it's in vk_scene.c
-extern int CL_FxBlend( cl_entity_t *e );
 
 void R_StudioSetRenderamt( int iRenderamt )
 {
@@ -3611,8 +3643,23 @@ void CL_InitStudioAPI( void )
 	pStudioDraw = &gStudioDraw;
 }
 
-void VK_StudioInit( void )
+void VK_StudioDrawModel( cl_entity_t *ent, int render_mode, float blend )
 {
+	RI.currententity = ent;
+	RI.currentmodel = ent->model;
+	RI.drawWorld = true;
+
+	g_studio.blend = blend;
+
+	R_DrawStudioModel( ent );
+
+	RI.currentmodel = NULL;
+	RI.currententity = NULL;
+}
+
+static qboolean Impl_Init( void ) {
+	XRVkModule_OnInitStart( g_module_studio );
+
 	Matrix3x4_LoadIdentity( g_studio.rotationmatrix );
 
 	// g-cont. cvar disabled by Valve
@@ -3627,24 +3674,14 @@ void VK_StudioInit( void )
 	R_SPEEDS_COUNTER(g_studio_stats.submodels_static, "submodels_static", kSpeedsMetricCount);
 	R_SPEEDS_COUNTER(g_studio_stats.submodels_dynamic, "submodels_dynamic", kSpeedsMetricCount);
 
-	VK_StudioModelInit();
+	XRVkModule_OnInitEnd( g_module_studio );
+	return true;
 }
 
-void VK_StudioShutdown( void )
-{
+static void Impl_Shutdown( void ) {
+	XRVkModule_OnShutdownStart( g_module_studio );
+
 	R_StudioCacheClear();
-}
 
-void VK_StudioDrawModel( cl_entity_t *ent, int render_mode, float blend )
-{
-	RI.currententity = ent;
-	RI.currentmodel = ent->model;
-	RI.drawWorld = true;
-
-	g_studio.blend = blend;
-
-	R_DrawStudioModel( ent );
-
-	RI.currentmodel = NULL;
-	RI.currententity = NULL;
+	XRVkModule_OnShutdownEnd( g_module_studio );
 }

--- a/ref/vk/vk_studio.h
+++ b/ref/vk/vk_studio.h
@@ -1,13 +1,13 @@
 #pragma once
 
+#include "vk_module.h"
 #include "vk_common.h"
+
+extern RVkModule g_module_studio;
 
 struct ref_viewpass_s;
 struct draw_list_s;
 struct model_s;
-
-void VK_StudioInit( void );
-void VK_StudioShutdown( void );
 
 void Mod_StudioLoadTextures( model_t *mod, void *data );
 void Mod_StudioUnloadTextures( void *data );

--- a/ref/vk/vk_studio_model.h
+++ b/ref/vk/vk_studio_model.h
@@ -1,7 +1,11 @@
 #pragma once
 
+#include "vk_module.h"
+
 #include "vk_render.h"
 #include "vk_geometry.h"
+
+extern RVkModule g_module_studio_model;
 
 struct r_studio_submodel_info_s;
 
@@ -63,6 +67,3 @@ typedef struct {
 	int bodyparts_count;
 	r_studio_submodel_render_t **bodyparts;
 } r_studio_entity_model_t;
-
-void VK_StudioModelInit(void);
-//void VK_StudioModelShutdown(void);

--- a/ref/vk/vk_swapchain.c
+++ b/ref/vk/vk_swapchain.c
@@ -4,6 +4,23 @@
 
 #include "eiface.h" // ARRAYSIZE
 
+static qboolean Impl_Init( void );
+static     void Impl_Shutdown( void );
+
+static RVkModule *required_modules[] = {
+	// createDepthImage: R_VkImageCreate
+	// destroySwapchainAndFramebuffers: R_VkImageDestroy
+	&g_module_image
+};
+
+RVkModule g_module_swapchain = {
+	.name = "swapchain",
+	.state = RVkModuleState_NotInitialized,
+	.dependencies = RVkModuleDependencies_FromStaticArray( required_modules ),
+	.Init = Impl_Init,
+	.Shutdown = Impl_Shutdown
+};
+
 extern ref_globals_t *gpGlobals;
 
 static struct {
@@ -181,28 +198,6 @@ static qboolean recreateSwapchainIfNeeded( qboolean force ) {
 	return true;
 }
 
-qboolean R_VkSwapchainInit( VkRenderPass render_pass, VkFormat depth_format ) {
-	const uint32_t prev_num_images = g_swapchain.num_images;
-
-	VkSurfaceCapabilitiesKHR surface_caps;
-	XVK_CHECK(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(vk_core.physical_device.device, vk_core.surface.surface, &surface_caps));
-
-/*
-[2023:10:09|13:03:52] Error: Validation: Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] Object 0: handle = 0x555556af6a00, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL does not support usage that includes VK_IMAGE_USAGE_STORAGE_BIT. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
-*/
-	//g_swapchain.image_format = VK_FORMAT_B8G8R8A8_SRGB;
-
-	g_swapchain.image_format = VK_FORMAT_B8G8R8A8_UNORM; // TODO get from surface_formats
-	g_swapchain.render_pass = render_pass;
-	g_swapchain.depth_format = depth_format;
-
-	return recreateSwapchainIfNeeded( true );
-}
-
-void R_VkSwapchainShutdown( void ) {
-	destroySwapchainAndFramebuffers( g_swapchain.swapchain );
-}
-
 r_vk_swapchain_framebuffer_t R_VkSwapchainAcquire(  VkSemaphore sem_image_available ) {
 	APROF_SCOPE_DECLARE_BEGIN(function, __FUNCTION__);
 
@@ -295,4 +290,46 @@ void R_VkSwapchainPresent( uint32_t index, VkSemaphore done ) {
 		default:
 			XVK_CHECK(present_result);
 	}
+}
+
+void R_VkSwapchainSetRenderPassAndDepthFormat_FIXME( VkRenderPass render_pass, VkFormat depth_format ) { // -- @RenderpassOwnershipMess
+	g_swapchain.render_pass = render_pass;
+	g_swapchain.depth_format = depth_format;
+}
+
+static qboolean Impl_Init( void ) {
+	XRVkModule_OnInitStart( g_module_swapchain );
+
+	const uint32_t prev_num_images = g_swapchain.num_images;
+
+	VkSurfaceCapabilitiesKHR surface_caps;
+	XVK_CHECK(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(vk_core.physical_device.device, vk_core.surface.surface, &surface_caps));
+
+/*
+[2023:10:09|13:03:52] Error: Validation: Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] Object 0: handle = 0x555556af6a00, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL does not support usage that includes VK_IMAGE_USAGE_STORAGE_BIT. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+*/
+	//g_swapchain.image_format = VK_FORMAT_B8G8R8A8_SRGB;
+
+	g_swapchain.image_format = VK_FORMAT_B8G8R8A8_UNORM; // TODO get from surface_formats
+
+	// These are set by R_VkSwapchainSetRenderPassAndDepthFormat_FIXME -- @RenderpassOwnershipMess
+	// g_swapchain.render_pass = render_pass;
+	// g_swapchain.depth_format = depth_format;
+
+	if ( !recreateSwapchainIfNeeded( true ) ) {
+		gEngine.Host_Error( S_ERROR "Couldn't create swapchain.\n" );
+		g_module_swapchain.state = RVkModuleState_NotInitialized;
+		return false;
+	}
+
+	XRVkModule_OnInitEnd( g_module_swapchain );
+	return true;
+}
+
+static void Impl_Shutdown( void ) {
+	XRVkModule_OnShutdownStart( g_module_swapchain );
+
+	destroySwapchainAndFramebuffers( g_swapchain.swapchain );
+
+	XRVkModule_OnShutdownEnd( g_module_swapchain );
 }

--- a/ref/vk/vk_swapchain.h
+++ b/ref/vk/vk_swapchain.h
@@ -1,13 +1,15 @@
 #include "vk_core.h"
+#include "vk_module.h"
 
 // TODO this needs to be negotiated by swapchain creation
 // however, currently render pass also needs it so ugh
 #define SWAPCHAIN_FORMAT VK_FORMAT_B8G8R8A8_UNORM //SRGB
 //#define SWAPCHAIN_FORMAT VK_FORMAT_B8G8R8A8_SRGB
 
+extern RVkModule g_module_swapchain;
+
 // TODO: move render pass and depth format away from this
-qboolean R_VkSwapchainInit( VkRenderPass pass, VkFormat depth_format );
-void R_VkSwapchainShutdown( void );
+void R_VkSwapchainSetRenderPassAndDepthFormat_FIXME( VkRenderPass render_pass, VkFormat depth_format ); // -- @RenderpassOwnershipMess
 
 typedef struct {
 	uint32_t index;

--- a/ref/vk/vk_textures.c
+++ b/ref/vk/vk_textures.c
@@ -19,6 +19,15 @@
 
 #include <math.h> // sqrt
 
+RVkModule g_module_textures = {
+	.name = "textures",
+	.data = &g_module_textures,
+	.state = RVkModuleState_PreInitialized,
+	.Init = Impl_Init,
+	.GetResultName = Impl_GetResultName,
+	.Shutdown = Impl_Shutdown
+};
+
 #define LOG_MODULE tex
 #define MODULE_NAME "textures"
 
@@ -49,17 +58,109 @@ static struct {
 	vk_texture_t blue_noise;
 } g_vktextures;
 
+// FIXME should be static
+void unloadSkybox( void );
+
+static VkSampler pickSamplerForFlags( texFlags_t flags );
+static qboolean uploadTexture( int index, vk_texture_t *tex, rgbdata_t *const *const layers, int num_layers, qboolean cubemap, colorspace_hint_e colorspace_hint );
+static void textureDestroy( unsigned int index );
+static void loadBlueNoiseTextures( void );
+
+RVkModuleResult Impl_Init( RVkModuleLogLevels log_levels, RVkModuleArgs args ) {
+	// TODO(nilsoncore): Implement RVkModule_GetNameHash
+	g_module_textures.hash = RVkModule_GetNameHash( g_module_textures.name ); 
+	g_module_textures.log_levels = 0;
+	g_module_textures.log_levels |= log_levels;
+
+	R_SPEEDS_METRIC(g_vktextures.stats.count, "count", kSpeedsMetricCount);
+	R_SPEEDS_METRIC(g_vktextures.stats.size_total, "size_total", kSpeedsMetricBytes);
+
+	// TODO really check device caps for this
+	gEngine.Image_AddCmdFlags( IL_DDS_HARDWARE | IL_KTX2_RAW );
+
+	g_vktextures.default_sampler = pickSamplerForFlags(0);
+
+	// NOTE(nilsoncore):
+	// old: ASSERT(g_vktextures.default_sampler != VK_NULL_HANDLE);
+	// new:
+	if ( g_vktextures.default_sampler == VK_NULL_HANDLE ) {
+		g_module_textures.state = RVkModuleState_FailedToInitialize;
+	 	return RVkModuleTexturesResult_DefaultSamplerCreationError;
+	}
+
+
+	/* FIXME
+	// validate cvars
+	R_SetTextureParameters();
+	*/
+
+	/* FIXME
+	gEngine.Cmd_AddCommand( "texturelist", R_TextureList_f, "display loaded textures list" );
+	*/
+
+	// Fill empty texture with references to the default texture
+	{
+		const VkImageView default_view = R_TextureGetByIndex(tglob.defaultTexture)->vk.image.view;
+
+		// NOTE(nilsoncore):
+		// old: ASSERT(default_view != VK_NULL_HANDLE);
+		// new:
+		if ( default_view == VK_NULL_HANDLE ) {
+			g_module_textures.state = RVkModuleState_FailedToInitialize;
+			return RVkModuleTexturesResult_DefaultImageViewAcquireError;
+		}
+
+		for (int i = 0; i < MAX_TEXTURES; ++i) {
+			const vk_texture_t *const tex = R_TextureGetByIndex(i);
+			if (tex->vk.image.view)
+				continue;
+
+			g_vktextures.dii_all_textures[i] = (VkDescriptorImageInfo){
+				.imageView =  default_view,
+				.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+				.sampler = g_vktextures.default_sampler,
+			};
+		}
+	}
+
+	// NOTE(nilsoncore):
+	//   This function will fallback to regular random generated textures,
+	// so the module will load and function either way.
+	//   Although we could make an optional 'something' (var, arg, etc.)
+	// that controls this behaviour.
+	loadBlueNoiseTextures();
+
+	g_module_textures.state = RVkModuleState_Initialized;
+	return RVkModuleTexturesResult_Success;
+};
+
+const char *Impl_GetResultName( RVkModuleResult result ) {
+	switch ( ( RVkModuleTexturesResult )result ) {
+		case RVkModuleTexturesResult_Success:                      return "Success";
+		case RVkModuleTexturesResult_DefaultSamplerCreationError:  return "DefaultSamplerCreationError";
+		case RVkModuleTexturesResult_DefaultImageViewAcquireError: return "DefaultImageViewAcquireError";
+		default:                                                   return "(invalid)";
+	}
+};
+
+void Impl_Shutdown( qboolean forced ) {
+	unloadSkybox();
+	R_VkTextureDestroy(-1, &g_vktextures.cubemap_placeholder);
+	R_VkTextureDestroy(-1, &g_vktextures.blue_noise);
+
+	for (int i = 0; i < COUNTOF(g_vktextures.samplers); ++i) {
+		if (g_vktextures.samplers[i].sampler != VK_NULL_HANDLE)
+			vkDestroySampler(vk_core.device, g_vktextures.samplers[i].sampler, NULL);
+	}
+
+	g_module_textures.state = ( forced ) ? RVkModuleState_ForcedShutdown : RVkModuleState_ManualShutdown;
+};
+
 // Exported from r_textures.h
 size_t CalcImageSize( pixformat_t format, int width, int height, int depth );
 int CalcMipmapCount( int width, int height, int depth, uint32_t flags, qboolean haveBuffer );
 qboolean validatePicLayers(const char* const name, rgbdata_t *const *const layers, int num_layers);
 void BuildMipMap( byte *in, int srcWidth, int srcHeight, int srcDepth, int flags );
-
-static VkSampler pickSamplerForFlags( texFlags_t flags );
-static qboolean uploadTexture(int index, vk_texture_t *tex, rgbdata_t *const *const layers, int num_layers, qboolean cubemap, colorspace_hint_e colorspace_hint);
-
-// FIXME should be static
-void unloadSkybox( void );
 
 // Hardcode blue noise texture size to 64x64x64
 #define BLUE_NOISE_SIZE 64
@@ -185,8 +286,6 @@ qboolean R_VkTexturesInit( void ) {
 
 	return true;
 }
-
-static void textureDestroy( unsigned int index );
 
 void R_VkTexturesShutdown( void ) {
 	unloadSkybox();

--- a/ref/vk/vk_textures.h
+++ b/ref/vk/vk_textures.h
@@ -1,11 +1,27 @@
 #pragma once
 
-#include "r_textures.h"
 #include "vk_core.h"
+#include "vk_module.h"
+
+#include "r_textures.h"
 #include "vk_image.h"
 #include "vk_const.h"
 
 #include "unordered_roadmap.h"
+
+// -- Module API implementation START --
+extern RVkModule g_module_textures;
+
+typedef enum {
+	RVkModuleTexturesResult_Success = RVkModuleResult_Success,
+	RVkModuleTexturesResult_DefaultSamplerCreationError,
+	RVkModuleTexturesResult_DefaultImageViewAcquireError
+} RVkModuleTexturesResult;
+
+static RVkModuleResult Impl_Init( RVkModuleLogLevels log_levels, RVkModuleArgs args );
+static    const char * Impl_GetResultName( RVkModuleResult result );
+static            void Impl_Shutdown( qboolean forced );
+// -- Module API implementation END --
 
 typedef struct vk_texture_s
 {

--- a/ref/vk/vk_textures.h
+++ b/ref/vk/vk_textures.h
@@ -9,19 +9,7 @@
 
 #include "unordered_roadmap.h"
 
-// -- Module API implementation START --
 extern RVkModule g_module_textures;
-
-typedef enum {
-	RVkModuleTexturesResult_Success = RVkModuleResult_Success,
-	RVkModuleTexturesResult_DefaultSamplerCreationError,
-	RVkModuleTexturesResult_DefaultImageViewAcquireError
-} RVkModuleTexturesResult;
-
-static RVkModuleResult Impl_Init( RVkModuleLogLevels log_levels, RVkModuleArgs args );
-static    const char * Impl_GetResultName( RVkModuleResult result );
-static            void Impl_Shutdown( qboolean forced );
-// -- Module API implementation END --
 
 typedef struct vk_texture_s
 {
@@ -46,9 +34,6 @@ typedef struct vk_texture_s
 } vk_texture_t;
 
 #define TEX_NAME(tex) ((tex)->hdr_.key)
-
-qboolean R_VkTexturesInit( void );
-void R_VkTexturesShutdown( void );
 
 qboolean R_VkTexturesSkyboxUpload( const char *name, const rgbdata_t *pic, colorspace_hint_e colorspace_hint, qboolean placeholder);
 void R_VkTexturesSkyboxUnload(void);

--- a/ref/vk/vk_triapi.c
+++ b/ref/vk/vk_triapi.c
@@ -9,6 +9,21 @@
 #define MAX_TRIAPI_VERTICES 1024
 #define MAX_TRIAPI_INDICES 4096
 
+static qboolean Impl_Init( void );
+static     void Impl_Shutdown( void );
+
+static RVkModule *required_modules[] = {
+	&g_module_sprite
+};
+
+RVkModule g_module_triapi = {
+	.name = "triapi",
+	.state = RVkModuleState_NotInitialized,
+	.dependencies = RVkModuleDependencies_FromStaticArray( required_modules ),
+	.Init = Impl_Init,
+	.Shutdown = Impl_Shutdown
+};
+
 static struct {
 	vk_vertex_t vertices[MAX_TRIAPI_VERTICES];
 	uint16_t indices[MAX_TRIAPI_INDICES];
@@ -18,8 +33,6 @@ static struct {
 	int texture_index;
 
 	vk_render_type_e render_type;
-
-	qboolean initialized;
 } g_triapi = {0};
 
 void TriSetTexture( int texture_index ) {
@@ -74,11 +87,6 @@ void TriBegin( int primitive_mode ) {
 	vk_vertex_t *const ve = g_triapi.vertices + 0;
 	if (g_triapi.num_vertices > 1)
 		*ve = g_triapi.vertices[g_triapi.num_vertices-1];
-
-	if (!g_triapi.initialized) {
-		Vector4Set(ve->color, 255, 255, 255, 255);
-		g_triapi.initialized = true;
-	}
 
 	g_triapi.primitive_mode = primitive_mode + 1;
 	g_triapi.num_vertices = 0;
@@ -221,4 +229,22 @@ void TriNormal3fv( const float *v ) {
 void TriNormal3f( float x, float y, float z ) {
 	vk_vertex_t *const ve = g_triapi.vertices + g_triapi.num_vertices;
 	VectorSet(ve->normal, x, y, z);
+}
+
+static qboolean Impl_Init( void ) {
+	XRVkModule_OnInitStart( g_module_triapi );
+
+	vk_vertex_t *const ve = g_triapi.vertices + 0;
+	Vector4Set(ve->color, 255, 255, 255, 255);
+
+	XRVkModule_OnInitEnd( g_module_triapi );
+	return true;
+}
+
+static void Impl_Shutdown( void ) {
+	XRVkModule_OnShutdownStart( g_module_triapi );
+
+	// Nothing to clear for now.
+
+	XRVkModule_OnShutdownEnd( g_module_triapi );
 }

--- a/ref/vk/vk_triapi.h
+++ b/ref/vk/vk_triapi.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include "vk_module.h"
+
 #include "xash3d_types.h"
+
+extern RVkModule g_module_triapi;
 
 typedef struct model_s model_t;
 


### PR DESCRIPTION
Как мы знаем, все наши `Vulkan`-овские модули внутри `ref/vk` так или иначе имеют концепцию инициализации и деинициализации посредством вызова функций:
- `xxx_Init()` - для инициализации модуля перед тем, как его использовать.
- `xxx_Shutdown()` - для деинициализации модуля после того, как им закончили пользоваться.
 
Данная концепция подразумевает, что перед тем, как использовать что-то из нужного нам модуля, мы сначала должны этот модуль инициализировать, а когда он нам не нужен, то мы вызываем деинициализацию, чтобы этот модуль сделал все необходимые действия для плавного возвращения всех ресурсов, которые он занял, обратно в систему.

Реализовано это у нас очень просто, но эта простота упускает реализацию достаточно важных деталей:
1. ### Состояние инициализации
Мы его просто напросто не знаем. То есть каждый раз перед тем, как использовать функционал модуля, мы должны либо инициализировать его, даже если он уже инициализирован, так как мы не знаем об этом, либо надеяться на то, что кто-то уже сделал это до нас.

2. ### Зависимости 
Все они задаются вручную и никак не отслеживаются самим модулем. Нет какого-то определенного списка зависимостей, который мы просто можем взять и посмотреть, а также, чтобы это сделал сам модуль и проинициализировал их, если это еще не было сделано. "Списки" этих зависимостей нигде не хранятся, кроме как в самом коде в виде вызовов их функций инициализации, которые обычно идут списком внутри функции `xxx_Init()`.

Этот PR является попыткой все это реорганизовать и вынести в отдельный, доведенный до ума API. Намеки на надобность такого рода API уже есть комментариях самого кода: 

https://github.com/w23/xash3d-fwgs/blob/a0b36a4301fbd718a4c3ae85bbe06d9efa50d6df/ref/vk/vk_core.c#L680-L707

Осталось лишь понять как именно этот API реализовать и что конкретно мы от него хотим. Я выделил следующие критерии (за исключением всяких "простота в использовании", "понятность" и т.д. - берем это, как базовые критерии):
1. Задание зависимостей - чтобы мы вручную не прописывали все `Init`-ы внутри других `Init`-ов.
2. Автоматическая иниациализация всех заданных зависимостей - чтобы мы вызвали у модуля `Init` и были уверены в том, что все зависимости будут прогружены и модуль будет готов к работе.
3. Результат инициализации - чтобы знать, что модуль инициализирован, а если нет, то в чем заключается ошибка.
4. Отслеживание состояния - чтобы знать текущее состояние модуля: еще не инициализирован, инициализирован, деинициализирован и т.д.

Это был небольшой `Specification`, надеюсь мои мысли и идеи совпадают с первоначальными.
Вот как примерно выглядит код инициализации и деинициализации модулей сейчас: 

https://github.com/w23/xash3d-fwgs/blob/a0b36a4301fbd718a4c3ae85bbe06d9efa50d6df/ref/vk/vk_core.c#L765-L783

https://github.com/w23/xash3d-fwgs/blob/a0b36a4301fbd718a4c3ae85bbe06d9efa50d6df/ref/vk/vk_core.c#L838-L853

Первоначально хотел показать реализацию непосредственно внедрив ее сразу, но столкнулся с тем, что не все модули имеют простой `Init` без аргументов - некоторые ожидают параметры, которые создаются на этапе других модулей, которые зависят от других и так далее...

Такая проблема есть в `vk_swapchain`, где инициализация ожидает внешние параметры:
https://github.com/w23/xash3d-fwgs/blob/a0b36a4301fbd718a4c3ae85bbe06d9efa50d6df/ref/vk/vk_swapchain.c#L184

Эти параметры потом сохраняются в глобальное состояние:
https://github.com/w23/xash3d-fwgs/blob/a0b36a4301fbd718a4c3ae85bbe06d9efa50d6df/ref/vk/vk_swapchain.c#L196-L197

Если посмотреть саму структуру где они хранятся, то видим комментарий, что они тут быть и не должны:
https://github.com/w23/xash3d-fwgs/blob/a0b36a4301fbd718a4c3ae85bbe06d9efa50d6df/ref/vk/vk_swapchain.c#L9-L12

Сам модуль `vk_swapchain` инициализируется в модуле `vk_framectl` (кстати не знаю что за `framectl`, понятно лишь то, что `frame` - значит связано с кадрами, #709):
https://github.com/w23/xash3d-fwgs/blob/a0b36a4301fbd718a4c3ae85bbe06d9efa50d6df/ref/vk/vk_framectl.c#L420-L432

Идем в заголовок и видим, что и здесь это не должно быть:
https://github.com/w23/xash3d-fwgs/blob/a0b36a4301fbd718a4c3ae85bbe06d9efa50d6df/ref/vk/vk_framectl.h#L13-L22

Если посмотреть чуть выше, то видим комментарий, что тут вообще всех этих глобальных переменных не должно быть: 
https://github.com/w23/xash3d-fwgs/blob/a0b36a4301fbd718a4c3ae85bbe06d9efa50d6df/ref/vk/vk_framectl.h#L8C1-L8C1
```c
// TODO most of the things below should not be global. Instead, they should be passed as an argument/context to all the drawing functions that want this info
```
Такой вложенности мне хватило, чтобы понять, что сам я тут точно не разберусь...
Наверно это надо в отдельную ишью вынести, ну ладно, написал значит написал, может потом создам, где сразу для всех модулей выпишу эти зависимости.

Жду отзывов на данное творение и возможные предложения/исправления.
        