### PR TITLE
Stuff done during streams E352-E354

### DIFF
--- a/ref/vk/NOTES.md
+++ b/ref/vk/NOTES.md
@@ -1079,3 +1079,11 @@ xash   vk (remapped)
 +Y = -X
 +X = +Z
 +Z = +Y
+
+# 2023-12-22 E352
+## sRGB vs γ blending
+Original:
+    `color = a + b`
+Our:
+    `color = sqrt(a*a + b*b)`
+There's nothing we can to do `a` only that would make it fake the "original" mixing result.

--- a/ref/vk/TODO.md
+++ b/ref/vk/TODO.md
@@ -1,6 +1,6 @@
 # 2023-12-28 E353
 - [x] track color spaces when passing colors into shaders
-- [ ] validation failure at startup, #723
+- [ ] validation failure at startup, #723 -- seems like memory corruption
 
 Longer-term agenda for current season:
 - [ ] Better PBR math, e.g.:

--- a/ref/vk/TODO.md
+++ b/ref/vk/TODO.md
@@ -1,6 +1,10 @@
+# 2023-12-29 E354
+- [x] Figure out why additive transparency differs visibly from raster
+- [x] Implement special legacy-blending in sRGB-γ colorspace
+
 # 2023-12-28 E353
 - [x] track color spaces when passing colors into shaders
-- [ ] validation failure at startup, #723 -- seems like memory corruption
+- [-] validation failure at startup, #723 -- seems like memory corruption
 
 Longer-term agenda for current season:
 - [ ] Better PBR math, e.g.:
@@ -9,13 +13,12 @@ Longer-term agenda for current season:
 	- [ ] Just make sure that all the BRDF math is correct
 - [ ] Transparency/translucency:
 	- [ ] Proper material mode for translucency, with reflections, refraction (index), fresnel, etc.
-	- [ ] Figure out why additive transparency differs visibly from raster
 	- [ ] Extract and specialize effects, e.g.
 		- [ ] Rays -> volumetrics
 		- [ ] Glow -> bloom
 		- [ ] Smoke -> volumetrics
 		- [ ] Sprites/portals -> emissive volumetrics
-		- [ ] Holo models -> emissive additive
+		- [x] Holo models -> emissive additive
 		- [ ] Some additive -> translucent
 		- [ ] what else
 - [ ] Render-graph-ish approach to resources.

--- a/ref/vk/TODO.md
+++ b/ref/vk/TODO.md
@@ -1,3 +1,7 @@
+# 2023-12-28 E353
+- [x] track color spaces when passing colors into shaders
+- [ ] validation failure at startup, #723
+
 Longer-term agenda for current season:
 - [ ] Better PBR math, e.g.:
 	- [ ] Black metals: https://github.com/w23/xash3d-fwgs/issues/666

--- a/ref/vk/shaders/bounce.comp
+++ b/ref/vk/shaders/bounce.comp
@@ -178,9 +178,8 @@ void computeBounce(ivec2 pix, vec3 direction, out vec3 diffuse, out vec3 specula
 		vec3 background = payload.base_color_a.rgb * ldiffuse;
 		background += lspecular * mix(vec3(1.), payload.base_color_a.rgb, hit_material.metalness);
 
-		vec3 emissive = vec3(0.);
-		traceSimpleBlending(pos, bounce_direction, payload.hit_t.w, emissive, background);
-		lighting = emissive + background;
+		const vec4 blend = traceLegacyBlending(pos, bounce_direction, payload.hit_t.w);
+		lighting = SRGBtoLINEAR(blend.rgb) + background * blend.a;
 	} else {
 		lighting = texture(skybox, bounce_direction).rgb * ubo.ubo.skybox_exposure;
 		//payload.emissive.rgb = texture(skybox, bounce_direction).rgb * ubo.ubo.skybox_exposure;

--- a/ref/vk/shaders/denoiser.comp
+++ b/ref/vk/shaders/denoiser.comp
@@ -42,7 +42,9 @@ layout(set = 0, binding = 18) uniform sampler3D blue_noise_texture;
 #include "bluenoise.glsl"
 #endif
 
-//layout(set = 0, binding = 19) uniform sampler2D textures[MAX_TEXTURES];
+layout(set = 0, binding = 19, rgba16f) uniform readonly image2D legacy_blend;
+
+//layout(set = 0, binding = 20) uniform sampler2D textures[MAX_TEXTURES];
 
 
 const int INDIRECT_SCALE = 2;
@@ -306,18 +308,19 @@ void main() {
 		colour = diffuse + specular;
 	}
 
+	const vec4 legacy_blend = imageLoad(legacy_blend, pix);
+
+	colour += imageLoad(emissive, pix).rgb;
+	// Revealage. TODO: which colorspace?
+	colour *= legacy_blend.a;
+
+	colour = LINEARtoSRGB(colour);
+
 // See issue https://github.com/w23/xash3d-fwgs/issues/668, map test_blendmode_additive_alpha.
-// This macro enabled adding emissive to the final color in the *incorrect* sRGB-γ space. But it makes
+// Adding emissive_blend to the final color in the *incorrect* sRGB-γ space. It makes
 // it look much more like the original. Adding emissive in the *correct* linear space differs
 // from the original a lot, and looks perceptively worse.
-#define ADD_EMISSIVE_IN_GAMMA_SPACE
-#ifndef ADD_EMISSIVE_IN_GAMMA_SPACE
-	// Physically correct, but looks dull
-	colour += imageLoad(emissive, pix).rgb;
-	colour = LINEARtoSRGB(colour);
-#else // INCORRECT
-	colour = LINEARtoSRGB(colour) + LINEARtoSRGB(imageLoad(emissive, pix).rgb);
-#endif
+	colour += legacy_blend.rgb;
 
 	imageStore(out_dest, pix, vec4(colour, 0./*unused*/));
 }

--- a/ref/vk/shaders/denoiser.comp
+++ b/ref/vk/shaders/denoiser.comp
@@ -306,8 +306,18 @@ void main() {
 		colour = diffuse + specular;
 	}
 
+// See issue https://github.com/w23/xash3d-fwgs/issues/668, map test_blendmode_additive_alpha.
+// This macro enabled adding emissive to the final color in the *incorrect* sRGB-γ space. But it makes
+// it look much more like the original. Adding emissive in the *correct* linear space differs
+// from the original a lot, and looks perceptively worse.
+#define ADD_EMISSIVE_IN_GAMMA_SPACE
+#ifndef ADD_EMISSIVE_IN_GAMMA_SPACE
+	// Physically correct, but looks dull
 	colour += imageLoad(emissive, pix).rgb;
 	colour = LINEARtoSRGB(colour);
+#else // INCORRECT
+	colour = LINEARtoSRGB(colour) + LINEARtoSRGB(imageLoad(emissive, pix).rgb);
+#endif
 
 	imageStore(out_dest, pix, vec4(colour, 0./*unused*/));
 }

--- a/ref/vk/shaders/ray_primary.comp
+++ b/ref/vk/shaders/ray_primary.comp
@@ -23,6 +23,7 @@ layout(set = 0, binding = 12, rgba16f) uniform writeonly image2D out_normals_gs;
 layout(set = 0, binding = 13, rgba8) uniform writeonly image2D out_material_rmxx;
 layout(set = 0, binding = 14, rgba16f) uniform writeonly image2D out_emissive;
 layout(set = 0, binding = 15, rgba32f) uniform writeonly image2D out_geometry_prev_position;
+layout(set = 0, binding = 16, rgba16f) uniform writeonly image2D out_legacy_blend;
 
 layout(set = 0, binding = 30, std430) readonly buffer ModelHeaders { ModelHeader a[]; } model_headers;
 layout(set = 0, binding = 31, std430) readonly buffer Kusochki { Kusok a[]; } kusochki;
@@ -118,7 +119,8 @@ void main() {
 		payload.emissive.rgb = texture(skybox, ray.direction).rgb * ubo.ubo.skybox_exposure;
 	}
 
-	traceSimpleBlending(ray.origin, ray.direction, L, payload.emissive.rgb, payload.base_color_a.rgb);
+	const vec4 blend = traceLegacyBlending(ray.origin, ray.direction, L);
+	imageStore(out_legacy_blend, pix, blend);
 
 	imageStore(out_position_t, pix, payload.hit_t);
 	imageStore(out_base_color_a, pix, LINEARtoSRGB(payload.base_color_a));

--- a/ref/vk/shaders/rt_geometry.glsl
+++ b/ref/vk/shaders/rt_geometry.glsl
@@ -134,7 +134,7 @@ Geometry readHitGeometry(vec2 bary, float ray_cone_width) {
 struct MiniGeometry {
 	vec2 uv;
 	uint kusok_index;
-	vec4 vertex_color;
+	vec4 vertex_color_srgb;
 };
 
 MiniGeometry readCandidateMiniGeometry(rayQueryEXT rq) {
@@ -156,16 +156,23 @@ MiniGeometry readCandidateMiniGeometry(rayQueryEXT rq) {
 		const vec2 bary = rayQueryGetIntersectionBarycentricsEXT(rq, false);
 		const vec2 uv = baryMix(uvs[0], uvs[1], uvs[2], bary);
 
+		/*
 		const vec4 colors[3] = {
 			SRGBtoLINEAR(unpackUnorm4x8(GET_VERTEX(vi1).color)),
 			SRGBtoLINEAR(unpackUnorm4x8(GET_VERTEX(vi2).color)),
 			SRGBtoLINEAR(unpackUnorm4x8(GET_VERTEX(vi3).color)),
 		};
+		*/
+		const vec4 colors_srgb[3] = {
+			unpackUnorm4x8(GET_VERTEX(vi1).color),
+			unpackUnorm4x8(GET_VERTEX(vi2).color),
+			unpackUnorm4x8(GET_VERTEX(vi3).color),
+		};
 
 		MiniGeometry ret;
 		ret.uv = uv;
 		ret.kusok_index = kusok_index;
-		ret.vertex_color = baryMix(colors[0], colors[1], colors[2], bary);
+		ret.vertex_color_srgb = baryMix(colors_srgb[0], colors_srgb[1], colors_srgb[2], bary);
 		return ret;
 }
 #endif // #ifdef RAY_QUERY

--- a/ref/vk/vk_brush.c
+++ b/ref/vk/vk_brush.c
@@ -830,6 +830,7 @@ void R_BrushModelDraw( const cl_entity_t *ent, int render_mode, float blend, con
 
 	vec4_t color = {1, 1, 1, 1};
 	vk_render_type_e render_type = kVkRenderTypeSolid;
+	uint32_t material_flags = kMaterialFlag_None;
 	switch (render_mode) {
 		case kRenderNormal:
 			Vector4Set(color, 1.f, 1.f, 1.f, 1.f);
@@ -846,6 +847,7 @@ void R_BrushModelDraw( const cl_entity_t *ent, int render_mode, float blend, con
 		case kRenderTransAdd:
 			Vector4Set(color, blend, blend, blend, 1.f);
 			render_type = kVkRenderType_A_1_R;
+			material_flags |= kMaterialFlag_CullBackFace_Bit;
 			break;
 		case kRenderTransAlpha:
 			if( gEngine.EngineGetParm( PARM_QUAKE_COMPATIBLE, 0 ))
@@ -950,7 +952,7 @@ void R_BrushModelDraw( const cl_entity_t *ent, int render_mode, float blend, con
 	R_RenderModelDraw(&bmodel->render_model, (r_model_draw_t){
 		.render_type = render_type,
 		.material_mode = material_mode,
-		.material_flags = kMaterialFlag_None,
+		.material_flags = material_flags,
 		.color = &color,
 		.transform = &transform,
 		.prev_transform = &bmodel->prev_transform,

--- a/ref/vk/vk_brush.c
+++ b/ref/vk/vk_brush.c
@@ -700,6 +700,7 @@ static void brushDrawWater(r_brush_water_model_t *wmodel, const cl_entity_t *ent
 	R_RenderModelDraw(&wmodel->render_model, (r_model_draw_t){
 		.render_type = render_type,
 		.material_mode = material_mode,
+		.material_flags = kMaterialFlag_None,
 		.color = (const vec4_t*)color,
 		.transform = (const matrix4x4*)transform,
 		.prev_transform = (const matrix4x4*)prev_transform,
@@ -949,6 +950,7 @@ void R_BrushModelDraw( const cl_entity_t *ent, int render_mode, float blend, con
 	R_RenderModelDraw(&bmodel->render_model, (r_model_draw_t){
 		.render_type = render_type,
 		.material_mode = material_mode,
+		.material_flags = kMaterialFlag_None,
 		.color = &color,
 		.transform = &transform,
 		.prev_transform = &bmodel->prev_transform,

--- a/ref/vk/vk_ray_accel.c
+++ b/ref/vk/vk_ray_accel.c
@@ -270,13 +270,16 @@ vk_resource_t RT_VkAccelPrepareTlas(vk_combuf_t *combuf) {
 				.instanceShaderBindingTableRecordOffset = 0,
 				.accelerationStructureReference = instance->blas_addr,
 			};
+
+			const VkGeometryInstanceFlagsKHR flags = (instance->material_flags & kMaterialFlag_CullBackFace_Bit) ? 0 : VK_GEOMETRY_INSTANCE_TRIANGLE_FACING_CULL_DISABLE_BIT_KHR;
+
 			switch (instance->material_mode) {
 				case MATERIAL_MODE_OPAQUE:
 					inst[i].mask = GEOMETRY_BIT_OPAQUE;
 					inst[i].instanceShaderBindingTableRecordOffset = SHADER_OFFSET_HIT_REGULAR,
 					// Force no-culling because there are cases where culling leads to leaking shadows, holes in reflections, etc
 					// CULL_DISABLE_BIT disables culling even if the gl_RayFlagsCullFrontFacingTrianglesEXT bit is set in shaders
-					inst[i].flags = VK_GEOMETRY_INSTANCE_FORCE_OPAQUE_BIT_KHR | VK_GEOMETRY_INSTANCE_TRIANGLE_FACING_CULL_DISABLE_BIT_KHR;
+					inst[i].flags = VK_GEOMETRY_INSTANCE_FORCE_OPAQUE_BIT_KHR | flags;
 					break;
 				case MATERIAL_MODE_OPAQUE_ALPHA_TEST:
 					inst[i].mask = GEOMETRY_BIT_ALPHA_TEST;
@@ -287,7 +290,7 @@ vk_resource_t RT_VkAccelPrepareTlas(vk_combuf_t *combuf) {
 					inst[i].mask = GEOMETRY_BIT_REFRACTIVE;
 					inst[i].instanceShaderBindingTableRecordOffset = SHADER_OFFSET_HIT_REGULAR,
 					// Disable culling for translucent surfaces: decide what side it is based on normal wrt ray directions
-					inst[i].flags = VK_GEOMETRY_INSTANCE_FORCE_OPAQUE_BIT_KHR | VK_GEOMETRY_INSTANCE_TRIANGLE_FACING_CULL_DISABLE_BIT_KHR;
+					inst[i].flags = VK_GEOMETRY_INSTANCE_FORCE_OPAQUE_BIT_KHR | flags;
 					break;
 				case MATERIAL_MODE_BLEND_ADD:
 				case MATERIAL_MODE_BLEND_MIX:
@@ -295,7 +298,7 @@ vk_resource_t RT_VkAccelPrepareTlas(vk_combuf_t *combuf) {
 					inst[i].mask = GEOMETRY_BIT_BLEND;
 					inst[i].instanceShaderBindingTableRecordOffset = SHADER_OFFSET_HIT_ADDITIVE,
 					// Force no-culling because these should be visible from any angle
-					inst[i].flags = VK_GEOMETRY_INSTANCE_FORCE_NO_OPAQUE_BIT_KHR | VK_GEOMETRY_INSTANCE_TRIANGLE_FACING_CULL_DISABLE_BIT_KHR;
+					inst[i].flags = VK_GEOMETRY_INSTANCE_FORCE_NO_OPAQUE_BIT_KHR | flags;
 					break;
 				default:
 					gEngine.Host_Error("Unexpected material mode %d\n", instance->material_mode);

--- a/ref/vk/vk_ray_internal.h
+++ b/ref/vk/vk_ray_internal.h
@@ -20,6 +20,7 @@ typedef struct rt_draw_instance_s {
 	matrix4x4 prev_transform_row;
 	vec4_t color;
 	uint32_t material_mode; // MATERIAL_MODE_ from ray_interop.h
+	uint32_t material_flags; // material_flag_bits_e
 } rt_draw_instance_t;
 
 typedef struct {

--- a/ref/vk/vk_ray_model.c
+++ b/ref/vk/vk_ray_model.c
@@ -337,6 +337,15 @@ static void sRGBtoLinearVec4(const vec4_t in, vec4_t out) {
 	out[3] = in[3];
 }
 
+static void sRGBAtoLinearVec4(const vec4_t in, vec4_t out) {
+	out[0] = sRGBtoLinearScalar(in[0]);
+	out[1] = sRGBtoLinearScalar(in[1]);
+	out[2] = sRGBtoLinearScalar(in[2]);
+
+	// α also needs to be linearized.
+	out[3] = sRGBtoLinearScalar(in[3]);
+}
+
 void RT_FrameAddModel( struct rt_model_s *model, rt_frame_add_model_t args ) {
 	if (!model || !model->blas)
 		return;
@@ -476,7 +485,7 @@ void RT_FrameAddOnce( rt_frame_add_once_t args ) {
 			break;
 		}
 
-		Vector4Copy(*args.color, dyn->colors[dyn->geometries_count]);
+		sRGBAtoLinearVec4(*args.color_srgb, dyn->colors[dyn->geometries_count]);
 		dyn->geometries[dyn->geometries_count++] = args.geometries[i];
 	}
 }

--- a/ref/vk/vk_ray_model.c
+++ b/ref/vk/vk_ray_model.c
@@ -361,6 +361,7 @@ void RT_FrameAddModel( struct rt_model_s *model, rt_frame_add_model_t args ) {
 	draw_instance->blas_addr = model->blas_addr;
 	draw_instance->kusochki_offset = kusochki_offset;
 	draw_instance->material_mode = args.material_mode;
+	draw_instance->material_flags = args.material_flags;
 	sRGBtoLinearVec4(*args.color_srgb, draw_instance->color);
 	Matrix3x4_Copy(draw_instance->transform_row, args.transform);
 	Matrix4x4_Copy(draw_instance->prev_transform_row, args.prev_transform);
@@ -453,6 +454,7 @@ void RT_DynamicModelProcessFrame(void) {
 		draw_instance->blas_addr = dyn->blas_addr;
 		draw_instance->kusochki_offset = kusochki_offset;
 		draw_instance->material_mode = i;
+		draw_instance->material_flags = 0;
 		Vector4Set(draw_instance->color, 1, 1, 1, 1);
 		Matrix3x4_LoadIdentity(draw_instance->transform_row);
 		Matrix4x4_LoadIdentity(draw_instance->prev_transform_row);

--- a/ref/vk/vk_render.c
+++ b/ref/vk/vk_render.c
@@ -844,7 +844,7 @@ void R_RenderDrawOnce(r_draw_once_t args) {
 		RT_FrameAddOnce((rt_frame_add_once_t){
 			.debug_name = args.name,
 			.geometries = &geometry,
-			.color = args.color,
+			.color_srgb = args.color,
 			.geometries_count = 1,
 			.render_type = args.render_type,
 		});

--- a/ref/vk/vk_render.c
+++ b/ref/vk/vk_render.c
@@ -791,6 +791,7 @@ void R_RenderModelDraw(const vk_render_model_t *model, r_model_draw_t args) {
 		ASSERT(model->rt_model);
 		RT_FrameAddModel(model->rt_model, (rt_frame_add_model_t){
 			.material_mode = args.material_mode,
+			.material_flags = args.material_flags,
 			.transform = (const matrix3x4*)args.transform,
 			.prev_transform = (const matrix3x4*)args.prev_transform,
 			.color_srgb = args.color,

--- a/ref/vk/vk_render.h
+++ b/ref/vk/vk_render.h
@@ -123,9 +123,15 @@ void R_RenderModelDestroy( vk_render_model_t* model );
 qboolean R_RenderModelUpdate( const vk_render_model_t *model );
 qboolean R_RenderModelUpdateMaterials( const vk_render_model_t *model, const int *geom_indices, int geom_indices_count);
 
+typedef enum {
+	kMaterialFlag_None = 0,
+	kMaterialFlag_CullBackFace_Bit = (1<<0),
+} material_flag_bits_e;
+
 typedef struct {
 	vk_render_type_e render_type; // TODO rename legacy
 	material_mode_e material_mode;
+	uint32_t material_flags; // material_flag_bits_e
 
 	// These are "consumed": copied into internal storage and can be pointers to stack vars
 	const vec4_t *color;

--- a/ref/vk/vk_rtx.h
+++ b/ref/vk/vk_rtx.h
@@ -78,7 +78,7 @@ void RT_FrameAddModel( struct rt_model_s *model, rt_frame_add_model_t args );
 typedef struct {
 	const char *debug_name;
 	const struct vk_render_geometry_s *geometries;
-	const vec4_t *color;
+	const vec4_t *color_srgb;
 	int geometries_count;
 	int render_type;
 } rt_frame_add_once_t;

--- a/ref/vk/vk_rtx.h
+++ b/ref/vk/vk_rtx.h
@@ -58,6 +58,8 @@ qboolean RT_ModelUpdateMaterials(struct rt_model_s *model, const struct vk_rende
 
 typedef struct {
 	int material_mode;
+	uint32_t material_flags;
+
 	const matrix3x4 *transform, *prev_transform;
 	const vec4_t *color_srgb;
 

--- a/ref/vk/vk_sprite.c
+++ b/ref/vk/vk_sprite.c
@@ -808,6 +808,7 @@ static void R_DrawSpriteQuad( const char *debug_name, const mspriteframe_t *fram
 	R_RenderModelDraw(&g_sprite.quad.model, (r_model_draw_t){
 		.render_type = render_type,
 		.material_mode = material_mode,
+		.material_flags = kMaterialFlag_None,
 		.color = (const vec4_t*)color,
 		.transform = &transform,
 		.prev_transform = &transform,

--- a/ref/vk/vk_studio.c
+++ b/ref/vk/vk_studio.c
@@ -2331,6 +2331,7 @@ static void R_StudioDrawPoints( void ) {
 	R_RenderModelDraw(&render_submodel->model, (r_model_draw_t){
 		.render_type = render_type,
 		.material_mode = material_mode,
+		.material_flags = kMaterialFlag_CullBackFace_Bit, // TODO for transparent only?
 		.color = &color,
 		.transform = &g_studio_current.entmodel->transform,
 		.prev_transform = &g_studio_current.entmodel->prev_transform,


### PR DESCRIPTION
- [x] tune emissive/additive blending so that it matches original, fixes #668
- [x] make additive studio and brush models single-sided, fixes #665
- [x] convert override_color (from TriApi) to linear space together with gamma
- [x] apply soft-alpha-depth universally, fixes #722 
