### PR TITLE
vk: rt: add workaround for holes in geometry

### DIFF
--- a/ref/vk/vk_ray_model.c
+++ b/ref/vk/vk_ray_model.c
@@ -141,6 +141,14 @@ uint32_t R_VkMaterialModeFromRenderType(vk_render_type_e render_type) {
 
 void RT_RayModel_Clear(void) {
 	R_DEBuffer_Init(&g_ray_model_state.kusochki_alloc, MAX_KUSOCHKI / 2, MAX_KUSOCHKI / 2);
+
+	// FIXME
+	// This is a dirty workaround for sub-part memory management in this little project
+	// Accel backing buffer gets cleared on NewMap. Therefore, we need to recreate BLASes for dynamic
+	// models, even though they might have lived for the entire process lifetime.
+	// See #729
+	RT_DynamicModelShutdown();
+	RT_DynamicModelInit();
 }
 
 void XVK_RayModel_ClearForNextFrame( void ) {


### PR DESCRIPTION
Once upon a time, there were some BLASes. There were the BLASes for dynamic geometry, that were to be used every frame to draw very dynamic things, like sprites and beams. They were initialized at the very begining of the renderer's lifetime, and were expected to live happily for the entire process duration. However, an evil NewMap appeared. It didn't care abount anything or anyone, so when it came, it just cleared all the allocators, and allowed other BLASes to be allocated into the same space as dynamic BLASes were already given. This made BLASes live on top of each other, use each others toys and make them fight. They weren't happy.

So we just kill them and creat them again from scratch, when the evil NewMap comes.

The end.

Fixes #729