### PR TITLE
optimize lighting: check shadow ray after brdf shading

### DIFF
--- a/ref/vk/shaders/light.glsl
+++ b/ref/vk/shaders/light.glsl
@@ -19,6 +19,9 @@ const float shadow_offset_fudge = .1;
 void computePointLights(vec3 P, vec3 N, uint cluster_index, vec3 view_dir, MaterialProperties material, out vec3 diffuse, out vec3 specular) {
 	diffuse = specular = vec3(0.);
 
+	// TODO blue noise
+	const vec2 rnd = vec2(rand01(), rand01());
+
 	//diffuse = vec3(1.);//float(lights.m.num_point_lights) / 64.);
 #define USE_CLUSTERS
 #ifdef USE_CLUSTERS
@@ -36,9 +39,6 @@ void computePointLights(vec3 P, vec3 N, uint cluster_index, vec3 view_dir, Mater
 
 		const vec3 spotlight_dir = lights.m.point_lights[i].dir_stopdot2.xyz;
 		const bool is_environment = (lights.m.point_lights[i].environment != 0);
-
-		// TODO blue noise
-		const vec2 rnd = vec2(rand01(), rand01());
 
 		vec3 light_dir;
 		vec3 color = lights.m.point_lights[i].color_stopdot.rgb;

--- a/ref/vk/shaders/light_polygon.glsl
+++ b/ref/vk/shaders/light_polygon.glsl
@@ -10,9 +10,9 @@
 #define DO_ALL_IN_CLUSTER 1
 
 #ifndef RAY_BOUNCE
-#define PROJECTED
+//#define PROJECTED
 //#define SOLID
-//#define SIMPLE_SOLID
+#define SIMPLE_SOLID
 #else
 //#define PROJECTED
 //#define SOLID
@@ -274,11 +274,12 @@ void sampleEmissiveSurfaces(vec3 P, vec3 N, vec3 view_dir, MaterialProperties ma
 		const float dist = - plane_dist / dot(light_sample_dir.xyz, poly.plane.xyz);
 		const vec3 emissive = poly.emissive;
 
-		if (!shadowed(P, light_sample_dir.xyz, dist)) {
-			//const float estimate = total_contrib;
-			const float estimate = light_sample_dir.w;
-			vec3 poly_diffuse = vec3(0.), poly_specular = vec3(0.);
-			evalSplitBRDF(N, light_sample_dir.xyz, view_dir, material, poly_diffuse, poly_specular);
+		//const float estimate = total_contrib;
+		const float estimate = light_sample_dir.w;
+		vec3 poly_diffuse = vec3(0.), poly_specular = vec3(0.);
+		evalSplitBRDF(N, light_sample_dir.xyz, view_dir, material, poly_diffuse, poly_specular);
+
+		if (luminance(poly_diffuse + poly_specular) > 0. && !shadowed(P, light_sample_dir.xyz, dist)) {
 			diffuse += emissive * estimate * poly_diffuse;
 			specular += emissive * estimate * poly_specular;
 


### PR DESCRIPTION
Увеличило производительность полигональных источников света

В комнате ученых пасс light_direct_poly занимал 19 миллисекунд. После изменений занимает 13 миллисекунд. Общая длительность кадра уменьшилась с 42-45 миллисекунд до 32-35 миллисекунд.

Главным изменением стала проверка яркости brdf затенения перед пусканием луча (до этого сначала пускался луч и только потом считался шейдинг). В результате лишние лучи пускались даже тогда, когда свет не падал на плоскость (этот расчет и происходит в brdf)

Порядок проверки не играл роли при PROJECTED варианте сэмплинга. Но при выборе SIMPLE_SOLID производительность выросла.

Точно так же без изменения порядка проверок SIMPLE_SOLID не увеличивала производительность относительно PROJECTED. Но вместе с изменением порядка проверок сэмплинг SIMPLE_SOLID увеличивает производительность.

UPDATE: Второй (небольшой) оптимизацией стало вынесение вычисления рандома вне функции сэмплинга источников света. Теперь для всех источников света в текселе считается один набор значений vec3 rnd. Это никак не влияет на визуал, т.к. эти значения варьируются в соседних текселях, что важнее

P.S.: в названии одного из коммитов указана ишью, но он к ней отношения не имеет

До изменения порядка и выбора SIMPLE_SOLID:
![image](https://github.com/user-attachments/assets/98aa71b8-d6c0-4a47-8301-3d5bf93d561a)

После изменения порядка и выбора SIMPLE_SOLID:
![image](https://github.com/user-attachments/assets/4806fe5e-21c2-464b-8963-9ae51a1f5fb5)

После оптимизации рандомных значений для источников света:
![image](https://github.com/user-attachments/assets/3ebaccac-4bc7-46b8-911e-328f21f8e59a)

Комната ученых (после изменений):
![image](https://github.com/user-attachments/assets/a7e878bb-a4e4-4eec-87de-4aff3bb21695)