### PR TITLE
vk: fixup a few invalid enum mixups

### DIFF
--- a/ref/vk/vk_mapents.c
+++ b/ref/vk/vk_mapents.c
@@ -239,7 +239,7 @@ static void fillLightFromProps( vk_light_entity_t *le, const entity_props_t *pro
 		le->style = props->style;
 	}
 
-	if (le->type != LightEnvironment && (!patch || (have_fields & Field__light))) {
+	if (le->type != LightTypeEnvironment && (!patch || (have_fields & Field__light))) {
 		weirdGoldsrcLightScaling(le->color);
 	}
 
@@ -798,7 +798,7 @@ static void orientSpotlights( void ) {
 		vk_light_entity_t *const light = g_map_entities.lights + i;
 		const xvk_mapent_target_t *target;
 
-		if (light->type != LightSpot && light->type != LightTypeEnvironment)
+		if (light->type != LightTypeSpot && light->type != LightTypeEnvironment)
 			continue;
 
 		if (light->target_entity[0] == '\0')

--- a/ref/vk/vk_sprite.c
+++ b/ref/vk/vk_sprite.c
@@ -432,11 +432,11 @@ static float R_GetSpriteFrameInterpolant( cl_entity_t *ent, mspriteframe_t **old
 		frame = psprite->numframes - 1;
 	}
 
-	if( psprite->frames[frame].type == FRAME_SINGLE )
+	if( psprite->frames[frame].type == SPR_SINGLE )
 	{
 		if( m_fDoInterp )
 		{
-			if( ent->latched.prevblending[0] >= psprite->numframes || psprite->frames[ent->latched.prevblending[0]].type != FRAME_SINGLE )
+			if( ent->latched.prevblending[0] >= psprite->numframes || psprite->frames[ent->latched.prevblending[0]].type != SPR_SINGLE )
 			{
 				// this can be happens when rendering switched between single and angled frames
 				// or change model on replace delta-entity


### PR DESCRIPTION
Enum variables were compared to wrong enum values. Light ones were only accidentally correct.